### PR TITLE
(doc) - Add note on dependecy:tree -Dverbose support in 3.0+

### DIFF
--- a/src/site/apt/examples/resolving-conflicts-using-the-dependency-tree.apt
+++ b/src/site/apt/examples/resolving-conflicts-using-the-dependency-tree.apt
@@ -53,3 +53,12 @@ mvn dependency:tree -Dverbose -Dincludes=commons-collections
 
   More specifically, in verbose mode the dependency tree shows dependencies that were omitted for: being a duplicate
   of another; conflicting with another's version and/or scope; and introducing a cycle into the dependency tree.
+
+* Verbose flag support in 3.0+ version
+
+  Support for <<<verbose>>> flag has been removed since maven-dependency-plugin 3.0 ({{{https://issues.apache.org/jira/browse/MDEP-494}MDEP-494}}).
+  Extra output can be obtained by using an older version until proper support is reintroduced.
+
++---+
+mvn org.apache.maven.plugins:maven-dependency-plugin:2.10:tree -Dverbose=true
++---+


### PR DESCRIPTION
Running `mvn dependency:tree -Dverbose` as suggested in docs produces non-verbose output and the following warning:
```
[INFO] --- maven-dependency-plugin:3.0.0:tree (default-cli) @ my-project ---
[INFO] Verbose not supported since maven-dependency-plugin 3.0
...
```

From what I gather, it was originally reported as [MDEP-374](https://issues.apache.org/jira/browse/MDEP-374) back in 2.8, then a workaround based on Maven2 was introduced only to be removed later with [MDEP-494](https://issues.apache.org/jira/browse/MDEP-494).

This PR updates documentation with a possible workaround.

--

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [ ] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

