### PR TITLE
[MDEP-628] Parameter `fileMappers` for unpack path rewriting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>3.6.0</version>
+      <version>3.7.0</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/it/projects/unpack-dependencies-with-filemappers/invoker.properties
+++ b/src/it/projects/unpack-dependencies-with-filemappers/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean package

--- a/src/it/projects/unpack-dependencies-with-filemappers/pom.xml
+++ b/src/it/projects/unpack-dependencies-with-filemappers/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+  
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>unpack-dependencies</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency:unpack-dependencies using fileMappers
+  </description>
+  
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.10</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <configuration>
+              <excludes>*.txt,META-INF/**</excludes>
+              <fileMappers>
+                <org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+                  <prefix>mapped/</prefix>
+                </org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+              </fileMappers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/unpack-dependencies-with-filemappers/verify.groovy
+++ b/src/it/projects/unpack-dependencies-with-filemappers/verify.groovy
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+expected = ['org','junit']
+
+for (item in expected)
+{
+    def file = new File(basedir, 'target/dependency/mapped/' + item)
+    if (!file.exists())
+    {
+       throw new RuntimeException("Missing "+file.name);
+    }
+}
+
+notExpected = ['META-INF','LICENSE.TXT']
+
+for (item in notExpected)
+{
+    def file = new File(basedir, 'target/dependency/' + item)
+    if (file.exists())
+    {
+       throw new RuntimeException("This file shouldn't be here: "+file.name);
+    }
+}
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -41,6 +41,7 @@ import org.codehaus.plexus.archiver.UnArchiver;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 import org.codehaus.plexus.archiver.manager.NoSuchArchiverException;
 import org.codehaus.plexus.archiver.zip.ZipUnArchiver;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.codehaus.plexus.components.io.fileselectors.IncludeExcludeFileSelector;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReflectionUtils;
@@ -193,12 +194,14 @@ public abstract class AbstractDependencyMojo
      * @param artifact {@link Artifact}
      * @param location The location.
      * @param encoding The encoding.
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting
+     *                    shall happen.
      * @throws MojoExecutionException in case of an error.
      */
-    protected void unpack( Artifact artifact, File location, String encoding )
+    protected void unpack( Artifact artifact, File location, String encoding, FileMapper[] fileMappers )
         throws MojoExecutionException
     {
-        unpack( artifact, location, null, null, encoding );
+        unpack( artifact, location, null, null, encoding, fileMappers );
     }
 
     /**
@@ -211,12 +214,14 @@ public abstract class AbstractDependencyMojo
      * @param excludes Comma separated list of file patterns to exclude i.e. <code>**&#47;*.xml,
      *                 **&#47;*.properties</code>
      * @param encoding Encoding of artifact. Set {@code null} for default encoding.
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting
+     *                    shall happen.
      * @throws MojoExecutionException In case of errors.
      */
-    protected void unpack( Artifact artifact, File location, String includes, String excludes, String encoding )
-        throws MojoExecutionException
+    protected void unpack( Artifact artifact, File location, String includes, String excludes, String encoding,
+                           FileMapper[] fileMappers ) throws MojoExecutionException
     {
-        unpack( artifact, artifact.getType(), location, includes, excludes, encoding );
+        unpack( artifact, artifact.getType(), location, includes, excludes, encoding, fileMappers );
     }
 
     /**
@@ -226,10 +231,12 @@ public abstract class AbstractDependencyMojo
      * @param includes includes list.
      * @param excludes excludes list.
      * @param encoding the encoding.
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting
+     *                    shall happen.
      * @throws MojoExecutionException in case of an error.
      */
     protected void unpack( Artifact artifact, String type, File location, String includes, String excludes,
-                           String encoding )
+                           String encoding, FileMapper[] fileMappers )
         throws MojoExecutionException
     {
         File file = artifact.getFile();
@@ -302,6 +309,8 @@ public abstract class AbstractDependencyMojo
             {
                 silenceUnarchiver( unArchiver );
             }
+
+            unArchiver.setFileMappers( fileMappers );
 
             unArchiver.extract();
         }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
@@ -25,6 +25,7 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
 import org.apache.maven.shared.dependencies.DependableCoordinate;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.codehaus.plexus.util.StringUtils;
 
 /**
@@ -119,6 +120,15 @@ public class ArtifactItem
      * A comma separated list of file patterns to exclude when unpacking the artifact.
      */
     private String excludes;
+
+    /**
+     * {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting shall happen.
+     *
+     * @since 3.1.2
+     *
+     * @parameter
+     */
+    private FileMapper[] fileMappers;
 
     /**
      * Default ctor.
@@ -380,5 +390,27 @@ public class ArtifactItem
     public void setIncludes( String includes )
     {
         this.includes = includes;
+    }
+
+    /**
+     * @return {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting shall
+     *         happen.
+     *
+     * @since 3.1.2
+     */
+    public FileMapper[] getFileMappers()
+    {
+        return this.fileMappers;
+    }
+
+    /**
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no
+     * rewriting shall happen.
+     *
+     * @since 3.1.2
+     */
+    public void setFileMappers( FileMapper[] fileMappers )
+    {
+        this.fileMappers = fileMappers;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -28,6 +28,7 @@ import org.apache.maven.plugins.dependency.utils.markers.UnpackFileMarkerHandler
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
 import org.codehaus.plexus.util.StringUtils;
 
 import java.io.File;
@@ -69,6 +70,14 @@ public class UnpackMojo
      */
     @Parameter( property = "mdep.unpack.excludes" )
     private String excludes;
+
+    /**
+     * {@link FileMapper} to be used for rewriting each target path, or {@code null} if no rewriting shall happen.
+     *
+     * @since 3.1.2
+     */
+    @Parameter( property = "mdep.unpack.filemappers" )
+    private FileMapper[] fileMappers;
 
     /**
      * The artifact to unpack from command line. A string of the form
@@ -126,7 +135,8 @@ public class UnpackMojo
         MarkerHandler handler = new UnpackFileMarkerHandler( artifactItem, this.markersDirectory );
 
         unpack( artifactItem.getArtifact(), artifactItem.getType(), artifactItem.getOutputDirectory(),
-                artifactItem.getIncludes(), artifactItem.getExcludes(), artifactItem.getEncoding() );
+                artifactItem.getIncludes(), artifactItem.getExcludes(), artifactItem.getEncoding(),
+                artifactItem.getFileMappers() );
         handler.setMarker();
     }
 
@@ -209,5 +219,27 @@ public class UnpackMojo
     public void setIncludes( String includes )
     {
         this.includes = includes;
+    }
+
+    /**
+     * @return {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting shall
+     *         happen.
+     *
+     * @since 3.1.2
+     */
+    public FileMapper[] getFileMappers()
+    {
+        return this.fileMappers;
+    }
+
+    /**
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no
+     * rewriting shall happen.
+     *
+     * @since 3.1.2
+     */
+    public void setFileMappers( FileMapper[] fileMappers )
+    {
+        this.fileMappers = fileMappers;
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/UnpackDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/UnpackDependenciesMojo.java
@@ -30,6 +30,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
+import org.codehaus.plexus.components.io.filemappers.FileMapper;
 
 import java.io.File;
 
@@ -74,6 +75,14 @@ public class UnpackDependenciesMojo
     private String encoding;
 
     /**
+     * {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting shall happen.
+     *
+     * @since 3.1.2
+     */
+    @Parameter( property = "mdep.unpack.filemappers" )
+    private FileMapper[] fileMappers;
+
+    /**
      * Main entry into mojo. This method gets the dependencies and iterates through each one passing it to
      * DependencyUtil.unpackFile().
      *
@@ -93,7 +102,7 @@ public class UnpackDependenciesMojo
             destDir = DependencyUtil.getFormattedOutputDirectory( useSubDirectoryPerScope, useSubDirectoryPerType,
                                                                   useSubDirectoryPerArtifact, useRepositoryLayout,
                                                                   stripVersion, outputDirectory, artifact );
-            unpack( artifact, destDir, getIncludes(), getExcludes(), getEncoding() );
+            unpack( artifact, destDir, getIncludes(), getExcludes(), getEncoding(), getFileMappers() );
             DefaultFileMarkerHandler handler = new DefaultFileMarkerHandler( artifact, this.markersDirectory );
             handler.setMarker();
         }
@@ -159,5 +168,27 @@ public class UnpackDependenciesMojo
     public String getEncoding()
     {
         return this.encoding;
+    }
+
+    /**
+     * @return {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no rewriting shall
+     *         happen.
+     *
+     * @since 3.1.2
+     */
+    public FileMapper[] getFileMappers()
+    {
+        return this.fileMappers;
+    }
+
+    /**
+     * @param fileMappers {@link FileMapper}s to be used for rewriting each target path, or {@code null} if no
+     *                   rewriting shall happen.
+     *
+     * @since 3.1.2
+     */
+    public void setFileMappers( FileMapper[] fileMappers )
+    {
+        this.fileMappers = fileMappers;
     }
 }

--- a/src/site/apt/examples/unpacking-filemapper.apt.vm
+++ b/src/site/apt/examples/unpacking-filemapper.apt.vm
@@ -1,0 +1,111 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Rewriting target path and file name
+  ------
+  Markus KARG
+  ------
+  2018-09-24
+  ------
+
+Rewriting target path and file name
+
+  When unpacking files, it is possible to rewrite each unpacked file's target path and file name within the target folder.
+  This is useful e. g. to add or remove prefixes (like cutting away top level folders etc.):
+
++---+
+<project>
+   [...]
+   <build>
+     <plugins>
+       <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-dependency-plugin</artifactId>
+         <version>${project.version}</version>
+         <executions>
+           <execution>
+             <id>unpack</id>
+             <phase>package</phase>
+             <goals>
+               <goal>unpack</goal>
+             </goals>
+             <configuration>
+               [...]
+               <artifactItems>
+                 <artifactItem>
+                   [...]
+                   <fileMappers>
+                     <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                       <pattern>^\Qx.y/z/\E</pattern>
+                       <replacement>./</replacement>
+                     </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+                   </fileMappers>
+                   [...]
+                 </artifactItem>
+               </artifactItems>
+               [...]
+             </configuration>
+           </execution>
+         </executions>
+       </plugin>
+     </plugins>
+   </build>
+   [...]
+ </project>
++---+
+
+  The above example effectively cuts away the prefix <<<x.y/z/>>> of each unpacked file's path, using a regular
+  expression and a replacement expression. Two tricks need to be used here: First, the regular expression uses <<<\Q>>>
+  and <<<\E>>> to demarcate pattern quoting, as the dot (<<<.>>>) is special character in a reqular expression. Second,
+  due to a restriction of Maven's POM syntax, the replacement cannot be empty (this would skip the file). Instead a
+  dot-slash (<<<./>>>) replacement is used, which is effectively a no-op for paths segments.
+
+  Any Plexus File Mapper (i. e. implementation of the interface
+  <<<org.codehaus.plexus.components.io.filemappers.FileMapper>>>) can be used, but there are three particularly useful.
+
+  The Regular Expression Mapper is useful to modify or cut away prefixes or suffixes, or to rewrite file extensions:
+
++---+
+ [...]
+ <org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+   <pattern>[...]</pattern>
+   <replacement>[...]</replacement>
+ </org.codehaus.plexus.components.io.filemappers.RegExpFileMapper>
+ [...]
++---+
+
+  The Prefix File Mapper is useful to add prefixes:
+
++---+
+ [...]
+ <org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+   <prefix>[...]</prefix>
+ </org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+ [...]
++---+
+
+  The Flatten File Mapper removes the path completey, effectively putting all files in the same folder:
+
++---+
+ [...]
+ <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
+ [...]
++---+
+
+  When multiple file mappers are given, the list gets executed from top to bottom. This might improve readability of
+  the overal rewriting action compared to using a singular (typically complex) regular expression.

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -127,6 +127,8 @@ ${project.name}
 
   * {{{./examples/unpacking-project-dependencies.html}Unpacking the Project Dependencies}}
 
+  * {{{./examples/unpacking-filemapper.html}Rewriting target path and file name}}
+
   * {{{./examples/using-dependencies-sources.html}Using Project Dependencies' Sources}}
 
   * {{{./examples/failing-the-build-on-dependency-analysis-warnings.html}Failing the Build on Dependency Analysis Warnings}}

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -37,6 +37,7 @@ under the License.
       <item name="Copying project dependencies" href="examples/copying-project-dependencies.html"/>
       <item name="Unpacking specific artifacts" href="examples/unpacking-artifacts.html"/>
       <item name="Unpacking the project dependencies" href="examples/unpacking-project-dependencies.html"/>
+      <item name="Rewriting target path and file name" href="examples/unpacking-filemapper.html"/>
       <item name="Using project dependencies' sources" href="examples/using-dependencies-sources.html"/>
       <item name="Failing the build on dependency analysis warnings" href="examples/failing-the-build-on-dependency-analysis-warnings.html"/>
       <item name="Exclude Dependencies from Dependency Analysis" href="examples/exclude-dependencies-from-dependency-analysis.html"/>


### PR DESCRIPTION
Solving [MDEP-628](https://issues.apache.org/jira/browse/MDEP-628).

The new parameter `fileMappers` (default: `null`) can be set to an implementation of the `org.codehaus.plexus.components.io.filemappers.FileMapper` interface to rewrite the target path of each unpacked file.

This is useful in case prefixes of target files names within the target directory shall be added (using `PrefixFileMapper`), changed or omitted (using `RegExpFileMapper`).