### PR TITLE
[MDEP-666] Re-enable integration test for tree goal

### DIFF
--- a/src/it/projects/tree/invoker.properties
+++ b/src/it/projects/tree/invoker.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.maven.version = !3.4+


### PR DESCRIPTION
Following this checklist to help us incorporate your contribution quickly and easily:

- [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed for the change (usually before you start working on it). Trivial changes like typos do not  require a JIRA issue. Your pull request should address just this issue, without pulling in other changes.
- [X] Each commit in the pull request should have a meaningful subject line and body.
- [X] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`, where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice is to use the JIRA issue title in the pull request title and in the first line of the commit message.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
- [X] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

To make clear that you license your contribution under  the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0) you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

When investigating [MDEP-666](https://issues.apache.org/jira/browse/MDEP-666) I noticed that the `tree` goal has both the unit tests and the integration tests disabled. The integration test works fine on my machine, and I'd love to see it enabled.

It would help a lot when actually fixing the aforementioned issue. I also tried re-enabling the unit tests, but they failed. Since they are in fact in-between unit and integration level, I'd rather leave them for now and add proper unit tests when fixing the bug.