### PR TITLE
[MDEP-676] fix test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-artifact-transfer</artifactId>
-      <version>0.12.0</version>
+      <version>0.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>


### PR DESCRIPTION
@hboutemy the upgrade broke one of the integration tests. Fixing this is going to require moving to Maven 3.1 as a minimum which requires some other changes. 