### PR TITLE
[MDEP-680] Use proper remote repositories to resolve plugins/dependencies

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -352,12 +352,7 @@ public abstract class AbstractDependencyMojo
      */
     public ProjectBuildingRequest newResolveArtifactProjectBuildingRequest()
     {
-        ProjectBuildingRequest buildingRequest =
-            new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
-
-        buildingRequest.setRemoteRepositories( remoteRepositories );
-
-        return buildingRequest;
+        return newProjectBuildingRequest( remoteRepositories );
     }
 
     /**
@@ -366,10 +361,15 @@ public abstract class AbstractDependencyMojo
      */
     protected ProjectBuildingRequest newResolvePluginProjectBuildingRequest()
     {
+        return newProjectBuildingRequest( remotePluginRepositories );
+    }
+
+    private ProjectBuildingRequest newProjectBuildingRequest( List<ArtifactRepository> repositories )
+    {
         ProjectBuildingRequest buildingRequest =
             new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
 
-        buildingRequest.setRemoteRepositories( remotePluginRepositories );
+        buildingRequest.setRemoteRepositories( repositories );
 
         return buildingRequest;
     }

--- a/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -91,6 +91,12 @@ public abstract class AbstractDependencyMojo
     private List<ArtifactRepository> remoteRepositories;
 
     /**
+     * Remote repositories which will be searched for plugins.
+     */
+    @Parameter( defaultValue = "${project.pluginArtifactRepositories}", readonly = true, required = true )
+    private List<ArtifactRepository> remotePluginRepositories;
+
+    /**
      * Contains the full list of projects in the reactor.
      */
     @Parameter( defaultValue = "${reactorProjects}", readonly = true )

--- a/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -361,6 +361,20 @@ public abstract class AbstractDependencyMojo
     }
 
     /**
+     * @return Returns a new ProjectBuildingRequest populated from the current session and the current project remote
+     *         repositories, used to resolve plugins.
+     */
+    protected ProjectBuildingRequest newResolvePluginProjectBuildingRequest()
+    {
+        ProjectBuildingRequest buildingRequest =
+            new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
+
+        buildingRequest.setRemoteRepositories( remotePluginRepositories );
+
+        return buildingRequest;
+    }
+
+    /**
      * @return Returns the project.
      */
     public MavenProject getProject()

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
@@ -38,8 +38,6 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import static java.lang.String.format;
-
 /**
  * Goal that resolves all project dependencies, including plugins and reports and their dependencies.
  *
@@ -122,10 +120,10 @@ public class GoOfflineMojo
 
         final Set<Artifact> results = new HashSet<>();
 
-        this.getLog().debug( String.format( "Resolving %s with following repositories:", type ) );
+        this.getLog().debug( "Resolving " + type + " with following repositories:" );
         for ( ArtifactRepository repo : buildingRequest.getRemoteRepositories() )
         {
-            getLog().debug( format( "#%s (%s)", repo.getId(), repo.getUrl() ) );
+            getLog().debug( "#" + repo.getId() + " (" + repo.getUrl() + ")" );
         }
 
         for ( DependableCoordinate dependableCoordinate : dependableCoordinates )

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
@@ -25,7 +25,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
 import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
@@ -52,7 +51,6 @@ import static java.lang.String.format;
 public class GoOfflineMojo
     extends AbstractResolveMojo
 {
-
     /**
      * Main entry into mojo. Gets the list of dependencies, resolves all that are not in the Reactor, and iterates
      * through displaying the resolved versions.
@@ -104,8 +102,8 @@ public class GoOfflineMojo
     {
         final Collection<Dependency> dependencies = getProject().getDependencies();
         final Set<DependableCoordinate> dependableCoordinates = new HashSet<>();
-        final ProjectBuildingRequest buildingRequest =
-                new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
+
+        final ProjectBuildingRequest buildingRequest = newResolveArtifactProjectBuildingRequest();
 
         for ( Dependency dependency : dependencies )
         {
@@ -174,8 +172,7 @@ public class GoOfflineMojo
         artifacts.addAll( reports );
         artifacts.addAll( plugins );
 
-        final ProjectBuildingRequest buildingRequest =
-                new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
+        final ProjectBuildingRequest buildingRequest = newResolvePluginProjectBuildingRequest();
 
         for ( Artifact artifact : artifacts )
         {

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.dependency.resolvers;
  */
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
@@ -37,6 +38,8 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import static java.lang.String.format;
 
 /**
  * Goal that resolves all project dependencies, including plugins and reports and their dependencies.
@@ -109,16 +112,23 @@ public class GoOfflineMojo
             dependableCoordinates.add( createDependendableCoordinateFromDependency( dependency ) );
         }
 
-        return resolveDependableCoordinate( buildingRequest, dependableCoordinates );
+        return resolveDependableCoordinate( buildingRequest, dependableCoordinates, "dependencies" );
     }
 
     private Set<Artifact> resolveDependableCoordinate( final ProjectBuildingRequest buildingRequest,
-                                                        final Collection<DependableCoordinate> dependableCoordinates )
+                                                        final Collection<DependableCoordinate> dependableCoordinates,
+                                                       final String type )
             throws DependencyResolverException
     {
         final TransformableFilter filter = getTransformableFilter();
 
         final Set<Artifact> results = new HashSet<>();
+
+        this.getLog().debug( String.format( "Resolving %s with following repositories:", type ) );
+        for ( ArtifactRepository repo : buildingRequest.getRemoteRepositories() )
+        {
+            getLog().debug( format( "#%s (%s)", repo.getId(), repo.getUrl() ) );
+        }
 
         for ( DependableCoordinate dependableCoordinate : dependableCoordinates )
         {
@@ -172,7 +182,7 @@ public class GoOfflineMojo
             dependableCoordinates.add( createDependendableCoordinateFromArtifact( artifact ) );
         }
 
-        return resolveDependableCoordinate( buildingRequest, dependableCoordinates );
+        return resolveDependableCoordinate( buildingRequest, dependableCoordinates, "plugins" );
     }
 
     private DependableCoordinate createDependendableCoordinateFromArtifact( final Artifact artifact )

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
@@ -21,17 +21,13 @@ package org.apache.maven.plugins.dependency.resolvers;
 
 import java.io.IOException;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactsFilter;
@@ -50,12 +46,6 @@ import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverE
 public class ResolvePluginsMojo
     extends AbstractResolveMojo
 {
-
-    /**
-     * Remote repositories which will be searched for plugins.
-     */
-    @Parameter( defaultValue = "${project.pluginArtifactRepositories}", readonly = true, required = true )
-    private List<ArtifactRepository> remotePluginRepositories;
 
     /**
      * Main entry into mojo. Gets the list of dependencies and iterates through displaying the resolved version.
@@ -194,10 +184,7 @@ public class ResolvePluginsMojo
             // continue;
             // }
 
-            ProjectBuildingRequest buildingRequest =
-                new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
-
-            buildingRequest.setRemoteRepositories( this.remotePluginRepositories );
+            ProjectBuildingRequest buildingRequest = newResolvePluginProjectBuildingRequest();
 
             // resolve the new artifact
             resolvedArtifacts.add( getArtifactResolver().resolveArtifact( buildingRequest, artifact ).getArtifact() );

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTest.java
@@ -33,99 +33,116 @@ import static org.apache.maven.plugins.dependency.AbstractDependencyMojoTest.Con
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class AbstractDependencyMojoTest extends TestCase {
+public class AbstractDependencyMojoTest extends TestCase
+{
+    private MavenSession session = mock( MavenSession.class );
 
-    private MavenSession session = mock(MavenSession.class);
-
-    private ProjectBuildingRequest buildingRequest = mock(ProjectBuildingRequest.class);
+    private ProjectBuildingRequest buildingRequest = mock( ProjectBuildingRequest.class );
 
     private ArrayList<ArtifactRepository> artifactRepos = new ArrayList<>();
 
     private ArrayList<ArtifactRepository> pluginRepos = new ArrayList<>();
 
-    static class ConcreteDependencyMojo extends AbstractDependencyMojo {
-        static ConcreteDependencyMojo createConcreteDependencyMojoWithArtifactRepositories(MavenSession mavenSession, List<ArtifactRepository> artifactRepos) throws NoSuchFieldException, IllegalAccessException {
+    static class ConcreteDependencyMojo extends AbstractDependencyMojo
+    {
+        static ConcreteDependencyMojo createConcreteDependencyMojoWithArtifactRepositories(
+                MavenSession mavenSession, List<ArtifactRepository> artifactRepos )
+                throws NoSuchFieldException, IllegalAccessException
+        {
             ConcreteDependencyMojo cdm = new ConcreteDependencyMojo();
             cdm.session = mavenSession;
 
-            Field par = AbstractDependencyMojo.class.getDeclaredField("remoteRepositories");
-            par.setAccessible(true);
-            par.set(cdm, artifactRepos);
+            Field par = AbstractDependencyMojo.class.getDeclaredField( "remoteRepositories" );
+            par.setAccessible( true );
+            par.set( cdm, artifactRepos );
 
             return cdm;
         }
 
-        static ConcreteDependencyMojo createConcreteDependencyMojoWithPluginRepositories(MavenSession mavenSession, List<ArtifactRepository> pluginRepos) throws NoSuchFieldException, IllegalAccessException {
+        static ConcreteDependencyMojo createConcreteDependencyMojoWithPluginRepositories(
+                MavenSession mavenSession, List<ArtifactRepository> pluginRepos )
+                throws NoSuchFieldException, IllegalAccessException
+        {
             ConcreteDependencyMojo cdm = new ConcreteDependencyMojo();
             cdm.session = mavenSession;
 
-            Field par = AbstractDependencyMojo.class.getDeclaredField("remotePluginRepositories");
-            par.setAccessible(true);
-            par.set(cdm, pluginRepos);
+            Field par = AbstractDependencyMojo.class.getDeclaredField( "remotePluginRepositories" );
+            par.setAccessible( true );
+            par.set( cdm, pluginRepos );
 
             return cdm;
         }
 
         @Override
-        protected void doExecute() {
+        protected void doExecute()
+        {
         }
     }
 
     @Override
-    protected void setUp() throws Exception {
-        pluginRepos.add(newRepositoryWithId("#pr-central"));
-        pluginRepos.add(newRepositoryWithId("#pr-plugins"));
+    protected void setUp() throws Exception
+    {
+        pluginRepos.add( newRepositoryWithId( "#pr-central" ) );
+        pluginRepos.add( newRepositoryWithId( "#pr-plugins" ) );
 
-        artifactRepos.add(newRepositoryWithId("#ar-central"));
-        artifactRepos.add(newRepositoryWithId("#ar-snapshots"));
-        artifactRepos.add(newRepositoryWithId("#ar-staging"));
+        artifactRepos.add( newRepositoryWithId( "#ar-central" ) );
+        artifactRepos.add( newRepositoryWithId( "#ar-snapshots" ) );
+        artifactRepos.add( newRepositoryWithId( "#ar-staging" ) );
 
-        when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
+        when( session.getProjectBuildingRequest() ).thenReturn( buildingRequest );
     }
 
-    private static ArtifactRepository newRepositoryWithId(String id)
+    private static ArtifactRepository newRepositoryWithId( String id )
     {
-        ArtifactRepository repo = mock(ArtifactRepository.class);
-        when(repo.getId()).thenReturn(id);
+        ArtifactRepository repo = mock( ArtifactRepository.class );
+        when( repo.getId() ).thenReturn( id );
         return repo;
     }
 
-    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesSize() throws NoSuchFieldException, IllegalAccessException {
-        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories(session, artifactRepos);
+    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesSize()
+            throws NoSuchFieldException, IllegalAccessException
+    {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories( session, artifactRepos );
 
         ProjectBuildingRequest pbr = mojo.newResolveArtifactProjectBuildingRequest();
         List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
 
-        assertEquals(3, rrepos.size());
+        assertEquals( 3, rrepos.size() );
     }
 
-    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesContents() throws NoSuchFieldException, IllegalAccessException {
-        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories(session, artifactRepos);
+    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesContents()
+            throws NoSuchFieldException, IllegalAccessException
+    {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories( session, artifactRepos );
 
         ProjectBuildingRequest pbr = mojo.newResolveArtifactProjectBuildingRequest();
         List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
 
-        assertEquals("#ar-central", rrepos.get(0).getId());
-        assertEquals("#ar-snapshots", rrepos.get(1).getId());
-        assertEquals("#ar-staging", rrepos.get(2).getId());
+        assertEquals( "#ar-central", rrepos.get( 0 ).getId() );
+        assertEquals( "#ar-snapshots", rrepos.get( 1 ).getId() );
+        assertEquals( "#ar-staging", rrepos.get( 2 ).getId() );
     }
 
-    public void testNewResolvePluginProjectBuildingRequestRemoteRepositoriesSize() throws NoSuchFieldException, IllegalAccessException {
-        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithPluginRepositories(session, pluginRepos);
+    public void testNewResolvePluginProjectBuildingRequestRemoteRepositoriesSize()
+            throws NoSuchFieldException, IllegalAccessException
+    {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithPluginRepositories( session, pluginRepos );
 
         ProjectBuildingRequest pbr = mojo.newResolvePluginProjectBuildingRequest();
         List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
 
-        assertEquals(2, rrepos.size());
+        assertEquals( 2, rrepos.size() );
     }
 
-    public void testNewResolvePluginProjectBuildingRequestRemoteRepositoriesContents() throws NoSuchFieldException, IllegalAccessException {
-        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithPluginRepositories(session, pluginRepos);
+    public void testNewResolvePluginProjectBuildingRequestRemoteRepositoriesContents()
+            throws NoSuchFieldException, IllegalAccessException
+    {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithPluginRepositories( session, pluginRepos );
 
         ProjectBuildingRequest pbr = mojo.newResolvePluginProjectBuildingRequest();
         List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
 
-        assertEquals("#pr-central", rrepos.get(0).getId());
-        assertEquals("#pr-plugins", rrepos.get(1).getId());
+        assertEquals( "#pr-central", rrepos.get( 0 ).getId() );
+        assertEquals( "#pr-plugins", rrepos.get( 1 ).getId() );
     }
 }

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTest.java
@@ -1,0 +1,95 @@
+package org.apache.maven.plugins.dependency;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import junit.framework.TestCase;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.ProjectBuildingRequest;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.maven.plugins.dependency.AbstractDependencyMojoTest.ConcreteDependencyMojo.createConcreteDependencyMojoWithArtifactRepositories;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AbstractDependencyMojoTest extends TestCase {
+
+    private MavenSession session = mock(MavenSession.class);
+
+    private ProjectBuildingRequest buildingRequest = mock(ProjectBuildingRequest.class);
+
+    private ArrayList<ArtifactRepository> artifactRepos = new ArrayList<>();
+
+    static class ConcreteDependencyMojo extends AbstractDependencyMojo {
+        static ConcreteDependencyMojo createConcreteDependencyMojoWithArtifactRepositories(MavenSession mavenSession, List<ArtifactRepository> artifactRepos) throws NoSuchFieldException, IllegalAccessException {
+            ConcreteDependencyMojo cdm = new ConcreteDependencyMojo();
+            cdm.session = mavenSession;
+
+            Field par = AbstractDependencyMojo.class.getDeclaredField("remoteRepositories");
+            par.setAccessible(true);
+            par.set(cdm, artifactRepos);
+
+            return cdm;
+        }
+
+        @Override
+        protected void doExecute() {
+        }
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        artifactRepos.add(newRepositoryWithId("#ar-central"));
+        artifactRepos.add(newRepositoryWithId("#ar-snapshots"));
+        artifactRepos.add(newRepositoryWithId("#ar-staging"));
+
+        when(session.getProjectBuildingRequest()).thenReturn(buildingRequest);
+    }
+
+    private static ArtifactRepository newRepositoryWithId(String id)
+    {
+        ArtifactRepository repo = mock(ArtifactRepository.class);
+        when(repo.getId()).thenReturn(id);
+        return repo;
+    }
+
+    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesSize() throws NoSuchFieldException, IllegalAccessException {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories(session, artifactRepos);
+
+        ProjectBuildingRequest pbr = mojo.newResolveArtifactProjectBuildingRequest();
+        List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
+
+        assertEquals(3, rrepos.size());
+    }
+
+    public void testNewResolveArtifactProjectBuildingRequestRemoteRepositoriesContents() throws NoSuchFieldException, IllegalAccessException {
+        AbstractDependencyMojo mojo = createConcreteDependencyMojoWithArtifactRepositories(session, artifactRepos);
+
+        ProjectBuildingRequest pbr = mojo.newResolveArtifactProjectBuildingRequest();
+        List<ArtifactRepository> rrepos = pbr.getRemoteRepositories();
+
+        assertEquals("#ar-central", rrepos.get(0).getId());
+        assertEquals("#ar-snapshots", rrepos.get(1).getId());
+        assertEquals("#ar-staging", rrepos.get(2).getId());
+    }
+}


### PR DESCRIPTION
I propose this change to resolve [MDEP-680](https://issues.apache.org/jira/browse/MDEP-680).

My understanding is as follows:
1. both `o.a.m...internal.Maven30DependencyResolver.resolveDependencies` and `o.a.m...internal.Maven31DependencyResolver.resolveDependencies` use `buildingRequest.getRemoteRepositories()`
2. `ResolvePluginsMojo` sets them explicitly: https://github.com/apache/maven-dependency-plugin/blob/6adc71cceb0cc8bfc05d0b6d1ff72652d7e39f33/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java#L200 but `GoOffline` doesn't. Thus as I observed effectively only central is used.

I recorded my steps of the preparation, actual fix and some clean-up in separate commits.

I'm pretty sure about the code change, as I successfully used new `go-offline` from snapshot plugin with several (multi-module, parent-child) projects with dependencies and plugins from multiple (i.e. non-central) repositories.


---

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)