### PR TITLE
[MDEP-437] - mdep.link=true creates symlink instead of physical copy

### DIFF
--- a/src/it/projects/copy-using-symlink/invoker.properties
+++ b/src/it/projects/copy-using-symlink/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources -Dmdep.link=true

--- a/src/it/projects/copy-using-symlink/pom.xml
+++ b/src/it/projects/copy-using-symlink/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency:copy -Dmdep.link=true
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.maven</groupId>
+                  <artifactId>maven-model</artifactId>
+                  <version>2.0.6</version>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/copy-using-symlink/verify.bsh
+++ b/src/it/projects/copy-using-symlink/verify.bsh
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.*;
+
+Path libDir = basedir.toPath().resolve( "target/dependency" );
+
+String[] expectedFiles = {
+    "maven-model-2.0.6.jar",
+};
+
+for ( String expectedFile : expectedFiles )
+{
+    Path path = libDir.resolve( expectedFile );
+    System.out.println( "Checking for existence of link " + path );
+    if ( !Files.isSymbolicLink( path ) )
+    {
+        throw new Exception( "Missing symlink " + path );
+    }
+}
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -40,6 +40,13 @@ import java.util.List;
 public class CopyMojo
     extends AbstractFromConfigurationMojo
 {
+    /**
+     * Link instead of copy
+
+     * @since 3.1.3
+     */
+    @Parameter( property = "mdep.link", defaultValue = "false" )
+    private boolean link = false;
 
     /**
      * Strip artifact version during copy
@@ -132,7 +139,14 @@ public class CopyMojo
     {
         File destFile = new File( artifactItem.getOutputDirectory(), artifactItem.getDestFileName() );
 
-        copyFile( artifactItem.getArtifact().getFile(), destFile );
+        if ( this.isLink() )
+        {
+            linkFile( artifactItem.getArtifact().getFile(), destFile );
+        }
+        else
+        {
+            copyFile( artifactItem.getArtifact().getFile(), destFile );
+        }
     }
 
     @Override
@@ -143,6 +157,22 @@ public class CopyMojo
                                 false, false, false, false, this.stripVersion, prependGroupId, useBaseVersion,
                                 item.getOutputDirectory() );
         return destinationNameOverrideFilter;
+    }
+
+    /**
+     * @return Returns whether to link instead of copy
+     */
+    public boolean isLink()
+    {
+        return this.link;
+    }
+
+    /**
+     * @param link Whether to link instead of copy.
+     */
+    public void setLink( boolean link )
+    {
+        this.link = link;
     }
 
     /**

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
@@ -21,6 +21,8 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -144,6 +146,20 @@ public class TestCopyMojo
         assertEquals( exist, file.exists() );
     }
 
+    public void assertFilesAreLinks( Collection<ArtifactItem> items, boolean areLinks )
+    {
+        for ( ArtifactItem item : items )
+        {
+            assertFileIsLink( item, areLinks );
+        }
+    }
+
+    public void assertFileIsLink( ArtifactItem item, boolean isLink )
+    {
+        Path path = item.getOutputDirectory().toPath().resolve( item.getDestFileName() );
+        assertEquals( isLink, Files.isSymbolicLink( path ) );
+    }
+
     public void testMojoDefaults()
     {
         CopyMojo themojo = new CopyMojo();
@@ -231,6 +247,20 @@ public class TestCopyMojo
         mojo.execute();
 
         assertFilesExist( list, true );
+    }
+
+    public void testLink()
+        throws Exception
+    {
+        List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
+
+        mojo.setArtifactItems( createArtifactItemArtifacts( list ) );
+        mojo.setLink( true );
+
+        mojo.execute();
+
+        assertFilesExist( list, true );
+        assertFilesAreLinks( list, true );
     }
 
     public void testCopyStripVersionSetInMojo()

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
@@ -36,13 +36,19 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.dependency.AbstractDependencyMojoTestCase;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
 import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.BlockJUnit4ClassRunner;
 
+@RunWith(BlockJUnit4ClassRunner.class)
 public class TestCopyMojo
     extends AbstractDependencyMojoTestCase
 {
     private CopyMojo mojo;
 
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
         super.setUp( "copy", false, false );
@@ -84,6 +90,7 @@ public class TestCopyMojo
         assertNull( item.getClassifier() );
     }
 
+    @Test
     public void testSetArtifactWithoutClassifier()
         throws Exception
     {
@@ -96,6 +103,7 @@ public class TestCopyMojo
         assertNull( item.getClassifier() );
     }
 
+    @Test
     public void testSetArtifact()
         throws Exception
     {
@@ -108,6 +116,7 @@ public class TestCopyMojo
         assertEquals( "e", item.getClassifier() );
     }
 
+    @Test
     public void testGetArtifactItems()
         throws Exception
     {
@@ -160,6 +169,7 @@ public class TestCopyMojo
         assertEquals( isLink, Files.isSymbolicLink( path ) );
     }
 
+    @Test
     public void testMojoDefaults()
     {
         CopyMojo themojo = new CopyMojo();
@@ -169,6 +179,7 @@ public class TestCopyMojo
         assertFalse( themojo.isStripClassifier() );
     }
 
+    @Test
     public void testCopyFile()
         throws Exception
     {
@@ -181,6 +192,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testCopyFileWithBaseVersion()
         throws Exception
     {
@@ -200,6 +212,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testSkip()
         throws Exception
     {
@@ -218,6 +231,7 @@ public class TestCopyMojo
 
     }
 
+    @Test
     public void testCopyFileNoOverwrite()
         throws Exception
     {
@@ -235,6 +249,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testCopyToLocation()
         throws Exception
     {
@@ -249,6 +264,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testLink()
         throws Exception
     {
@@ -263,6 +279,7 @@ public class TestCopyMojo
         assertFilesAreLinks( list, true );
     }
 
+    @Test
     public void testCopyStripVersionSetInMojo()
         throws Exception
     {
@@ -280,6 +297,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testCopyStripClassifierSetInMojo()
         throws Exception
     {
@@ -298,6 +316,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testNonClassifierStrip()
         throws Exception
     {
@@ -310,6 +329,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testNonClassifierNoStrip()
         throws Exception
     {
@@ -322,6 +342,7 @@ public class TestCopyMojo
         assertFilesExist( list, true );
     }
 
+    @Test
     public void testMissingVersionNotFound()
         throws Exception
     {
@@ -370,6 +391,7 @@ public class TestCopyMojo
         return list;
     }
 
+    @Test
     public void testMissingVersionFromDependencies()
         throws Exception
     {
@@ -392,6 +414,7 @@ public class TestCopyMojo
         assertEquals( "2.0-SNAPSHOT", item.getVersion() );
     }
 
+    @Test
     public void testMissingVersionFromDependenciesLooseMatch()
         throws Exception
     {
@@ -423,6 +446,7 @@ public class TestCopyMojo
         assertEquals( "2.1", item.getVersion() );
     }
 
+    @Test
     public void testMissingVersionFromDependenciesWithClassifier()
         throws Exception
     {
@@ -468,6 +492,7 @@ public class TestCopyMojo
         return list;
     }
 
+    @Test
     public void testMissingVersionFromDependencyMgt()
         throws Exception
     {
@@ -501,6 +526,7 @@ public class TestCopyMojo
         assertEquals( "3.0-SNAPSHOT", item.getVersion() );
     }
 
+    @Test
     public void testMissingVersionFromDependencyMgtLooseMatch()
         throws Exception
     {
@@ -541,6 +567,7 @@ public class TestCopyMojo
         assertEquals( "3.1", item.getVersion() );
     }
 
+    @Test
     public void testMissingVersionFromDependencyMgtWithClassifier()
         throws Exception
     {
@@ -574,12 +601,14 @@ public class TestCopyMojo
         assertEquals( "3.1", item.getVersion() );
     }
 
+    @Test
     public void testArtifactNotFound()
         throws Exception
     {
         dotestArtifactExceptions( false, true );
     }
 
+    @Test
     public void testArtifactResolutionException()
         throws Exception
     {
@@ -612,6 +641,7 @@ public class TestCopyMojo
         }
     }
 
+    @Test
     public void testNoArtifactItems()
     {
         try
@@ -626,6 +656,7 @@ public class TestCopyMojo
 
     }
 
+    @Test
     public void testCopyDontOverWriteReleases()
         throws Exception
     {
@@ -657,6 +688,7 @@ public class TestCopyMojo
         assertEquals( time, copiedFile.lastModified() );
     }
 
+    @Test
     public void testCopyDontOverWriteSnapshots()
         throws Exception
     {
@@ -688,6 +720,7 @@ public class TestCopyMojo
         assertEquals( time, copiedFile.lastModified() );
     }
 
+    @Test
     public void testCopyOverWriteReleases()
         throws Exception
     {
@@ -717,6 +750,7 @@ public class TestCopyMojo
         assertEquals( 1000L, timeCopyNow );
     }
 
+    @Test
     public void testCopyOverWriteSnapshot()
         throws Exception
     {
@@ -747,6 +781,7 @@ public class TestCopyMojo
         assertEquals( 1000L, timeCopyNow );
     }
 
+    @Test
     public void testCopyOverWriteIfNewer()
         throws Exception
     {
@@ -776,6 +811,7 @@ public class TestCopyMojo
         assertTrue( time < copiedFile.lastModified() );
     }
 
+    @Test
     public void testCopyFileWithOverideLocalRepo()
         throws Exception
     {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestCopyMojo.java
@@ -19,9 +19,12 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
  * under the License.    
  */
 
+import static org.junit.Assume.assumeTrue;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.FileSystemException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -155,6 +158,27 @@ public class TestCopyMojo
         assertEquals( exist, file.exists() );
     }
 
+    private static final boolean supportsSymbolicLinks = supportsSymbolicLinks();
+
+    private static boolean supportsSymbolicLinks( )
+    {
+        try {
+            Path target = Files.createTempFile( null, null );
+            Path link = Files.createTempFile( null, null );
+            Files.delete( link );
+            try {
+                Files.createSymbolicLink( link, target );
+            } catch ( FileSystemException e ) {
+                return false;
+            }
+            Files.delete( link );
+            Files.delete( target );
+            return true;
+        } catch ( IOException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
     public void assertFilesAreLinks( Collection<ArtifactItem> items, boolean areLinks )
     {
         for ( ArtifactItem item : items )
@@ -268,6 +292,8 @@ public class TestCopyMojo
     public void testLink()
         throws Exception
     {
+        assumeTrue("supports symbolic links", supportsSymbolicLinks);
+
         List<ArtifactItem> list = stubFactory.getArtifactItems( stubFactory.getClassifiedArtifacts() );
 
         mojo.setArtifactItems( createArtifactItemArtifacts( list ) );


### PR DESCRIPTION
This PR proposes an implementation of [MDEP-437]: It provides a new property `mdep.link=true` (default is `false`) which lets the `copy` mojo produce symlinks instead of physical copies.

The benefit is that the user of this mojo now has control whether to invest time and space for real copies, or whether to spare it and just live with symbolic links.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)