### PR TITLE
Revert "Bump plexus-archiver from 4.2.2 to 4.2.3"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@ under the License.
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-archiver</artifactId>
-      <version>4.2.3</version>
+      <version>4.2.2</version>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
Reverts apache/maven-dependency-plugin#111, due to [my comment there](https://github.com/apache/maven-dependency-plugin/pull/111#issuecomment-707643034):

> This upgrade is necessary to fix [MDEP-651](https://issues.apache.org/jira/browse/MDEP-651), but some tests are failing on my machine. Need to investigate before I'd merge.
