### PR TITLE
[MDEP-714] - Add analyze parameter "ignoreUnusedRuntime"

### DIFF
--- a/src/it/projects/mdep-714-analyze-ignore-unused-runtime/invoker.properties
+++ b/src/it/projects/mdep-714-analyze-ignore-unused-runtime/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/projects/mdep-714-analyze-ignore-unused-runtime/pom.xml
+++ b/src/it/projects/mdep-714-analyze-ignore-unused-runtime/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency:analyze with ignoreUnusedRuntime
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.0.6</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+           <verbose>true</verbose>
+           <failOnWarning>true</failOnWarning>
+           <ignoreUnusedRuntime>true</ignoreUnusedRuntime>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/mdep-714-analyze-ignore-unused-runtime/src/main/java/Main.java
+++ b/src/it/projects/mdep-714-analyze-ignore-unused-runtime/src/main/java/Main.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -332,7 +332,7 @@ public abstract class AbstractAnalyzeMojo
         
         if ( ignoreUnusedRuntime )
         {
-            filterUnusedByScope( unusedDeclared, Artifact.SCOPE_RUNTIME );
+            filterArtifactsByScope( unusedDeclared, Artifact.SCOPE_RUNTIME );
         }
 
         ignoredUsedUndeclared.addAll( filterDependencies( usedUndeclared, ignoredDependencies ) );
@@ -413,9 +413,9 @@ public abstract class AbstractAnalyzeMojo
         return warning;
     }
 
-    private void filterUnusedByScope( Set<Artifact> unusedDeclared, String scope )
+    private void filterArtifactsByScope( Set<Artifact> artifacts, String scope )
     {
-        for ( Iterator<Artifact> iterator = unusedDeclared.iterator(); iterator.hasNext(); )
+        for ( Iterator<Artifact> iterator = artifacts.iterator(); iterator.hasNext(); )
         {
             Artifact artifact = iterator.next();
             if ( artifact.getScope().equals( scope ) )

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -102,6 +102,12 @@ public abstract class AbstractAnalyzeMojo
     private boolean ignoreNonCompile;
 
     /**
+     * Ignore Runtime scope for unused dependency analysis.
+     */
+    @Parameter( property = "ignoreUnusedRuntime", defaultValue = "false" )
+    private boolean ignoreUnusedRuntime;
+
+    /**
      * Output the xml for the missing dependencies (used but not declared).
      *
      * @since 2.0-alpha-5
@@ -323,6 +329,11 @@ public abstract class AbstractAnalyzeMojo
 
         Set<Artifact> ignoredUsedUndeclared = new LinkedHashSet<>();
         Set<Artifact> ignoredUnusedDeclared = new LinkedHashSet<>();
+        
+        if ( ignoreUnusedRuntime )
+        {
+            filterUnusedByScope( unusedDeclared, Artifact.SCOPE_RUNTIME );
+        }
 
         ignoredUsedUndeclared.addAll( filterDependencies( usedUndeclared, ignoredDependencies ) );
         ignoredUsedUndeclared.addAll( filterDependencies( usedUndeclared, ignoredUsedUndeclaredDependencies ) );
@@ -400,6 +411,18 @@ public abstract class AbstractAnalyzeMojo
         }
 
         return warning;
+    }
+
+    private void filterUnusedByScope( Set<Artifact> unusedDeclared, String scope )
+    {
+        for ( Iterator<Artifact> iterator = unusedDeclared.iterator(); iterator.hasNext(); )
+        {
+            Artifact artifact = iterator.next();
+            if ( artifact.getScope().equals( scope ) )
+            {
+                iterator.remove();
+            }
+        }
     }
 
     private void logArtifacts( Set<Artifact> artifacts, boolean warn )


### PR DESCRIPTION
When using `runtime` scoped dependencies, e.g. an JDBC driver, those dependencies are typically not directly referenced from within class files and therefore declared as "unused" by the analysis goals.

This change introduces a new boolean property, called `ignoreUnusedRuntime`, which suppresses runtime scoped unused dependencies if set to `true`.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)