### PR TITLE
[MDEP-693] - `dependency:analyze-only` goal fails on OpenJDK 14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ under the License.
       <dependency> <!-- override older version in maven-dependency-analyzer:1.11.3 -->
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.0</version>
+        <version>9.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
# Solution
1. Upgrade the `org.ow2.asm:asm` Maven dependency version to at least 9.0. Upgraded to the 9.1 version that as per [its release notes](https://asm.ow2.io/versions.html) introduced the JDK 17 support.
2. Upgrade the `org.apache.maven.shared:maven-dependency-analyzer` Maven dependency version to at least 1.11.3. Already upgraded.

# Pull request changes
Upgraded Maven dependency: `org.ow2.asm:asm`: from 9.0 to 9.1.

# Request for release
May you please release the new version of the `maven-dependency-plugin`, once the pull request has been merged?

# Individual Contributor License Agreement
I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0).

Best regards,  
Sergey Brunov.