### PR TITLE
[MDEP-739] Dependency Plugin go-offline doesn't respect artifact classifier

### DIFF
--- a/src/it/projects/mdep-739-go-offline-respect-classifiers/invoker.properties
+++ b/src/it/projects/mdep-739-go-offline-respect-classifiers/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:go-offline

--- a/src/it/projects/mdep-739-go-offline-respect-classifiers/pom.xml
+++ b/src/it/projects/mdep-739-go-offline-respect-classifiers/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.plugins.dependency</groupId>
+  <artifactId>mdep-739-go-offline-respect-classifiers</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <description>Test that dependency:go-offline respects classifiers on artifacts</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+      <scope>test</scope>
+      <type>test-jar</type>
+      <classifier>test-binder</classifier>
+      <version>3.1.2</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/mdep-739-go-offline-respect-classifiers/verify.groovy
+++ b/src/it/projects/mdep-739-go-offline-respect-classifiers/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String buildLog = file.getText( "UTF-8" );
+assert buildLog.contains( 'Resolved dependency: spring-cloud-stream-3.1.2-test-binder.jar' );
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/GoOfflineMojo.java
@@ -187,6 +187,7 @@ public class GoOfflineMojo
         result.setArtifactId( artifact.getArtifactId() );
         result.setVersion( artifact.getVersion() );
         result.setType( artifact.getType() );
+        result.setClassifier( artifact.getClassifier() );
 
         return result;
     }
@@ -198,6 +199,7 @@ public class GoOfflineMojo
         result.setArtifactId( dependency.getArtifactId() );
         result.setVersion( dependency.getVersion() );
         result.setType( dependency.getType() );
+        result.setClassifier( dependency.getClassifier() );
 
         return result;
     }


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
       [MDEP-739](https://issues.apache.org/jira/projects/MDEP/issues/MDEP-739?filter=allopenissues)
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
       See description below
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

### Description
The go-offline plugin maps Artifact and Dependency objects to DependableCoordinate, which are then downloaded.
In the conversion to DependenableCoordinate, the Artifact/Dependency classifier was not included, which caused issues similar to 

```
org.eclipse.aether.resolution.DependencyResolutionException: org.springframework.cloud:spring-cloud-stream:jar:tests:3.1.2 was not found in <repository>.
```

### Impact
The dependency:go-offline is used to prepare maven dependencies in our CI system to allow share dependencies between different steps in our build pipeline. This bug currently breaks our CI pipeline. 

Rolling back to maven-dependency-plugin version 3.1.1 is not an option due to [MDEP-204](https://issues.apache.org/jira/browse/MDEP-204) and other workarounds require republishing artifact without a classifier, which is also not desirable.