### PR TITLE
Fix source repo link

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -114,7 +114,7 @@ ${project.name}
   concern. Especially for fixing bugs it is crucial that the developers can reproduce your problem. For this reason,
   entire debug logs, POMs or most preferably little demo projects attached to the issue are very much appreciated.
   Of course, patches are welcome, too. Contributors can check out the project from our
-  {{{./source-repository.html}source repository}} and will find supplementary information in the
+  {{{./scm.html}source repository}} and will find supplementary information in the
   {{{http://maven.apache.org/guides/development/guide-helping.html}guide to helping with Maven}}.
 
 * Examples


### PR DESCRIPTION
The link to _source repository_ points to a non-existing page.
Modified the link to the appropriate page.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
