### PR TITLE
Update maven plugin tools and set maven core deps to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,6 +90,7 @@ under the License.
 
   <properties>
     <mavenVersion>3.1.1</mavenVersion>
+    <mavenPluginToolsVersion>3.6.2-SNAPSHOT</mavenPluginToolsVersion>
     <doxiaVersion>1.10</doxiaVersion>
     <doxiaSitetoolsVersion>1.10</doxiaSitetoolsVersion>
     <jettyVersion>9.4.41.v20210516</jettyVersion>
@@ -115,36 +116,43 @@ under the License.
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-repository-metadata</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-settings</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
       <version>${mavenVersion}</version>
+      <scope>provided</scope>
     </dependency>
     
     <!-- reporting -->
@@ -277,11 +285,13 @@ under the License.
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-api</artifactId>
       <version>0.9.0.M2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-util</artifactId>
       <version>0.9.0.M2</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.eclipse.aether</groupId>


### PR DESCRIPTION
Once new plugin tools released, this one should be merged.

There was a bug https://issues.apache.org/jira/browse/MPLUGIN-372 that prevented us to do this.