### PR TITLE
Update transitive dependency to non-vulnerable version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,12 @@ under the License.
       <version>${slf4j.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.4</version>
+    </dependency>
+
   </dependencies>
 
   <build>


### PR DESCRIPTION
The current transitive dependency `commons-beanutils-1.7.0` is vulnerable: https://www.cve.org/CVERecord?id=CVE-2014-0114.