### PR TITLE
Exclude vulnerable commons-beanutils-1.7.0 from maven-reporting-impl …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,12 @@ under the License.
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-impl</artifactId>
       <version>3.1.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
I saw team has remove the dependency of doxia-site-renderer and upgrade maven-reporting-impl from 3.0 to 3.1, but the 
commons-beanutils-1.7.0 is still in maven-reporting-impl:3.1. Hope we could exclude the vulnerable version.