### PR TITLE
[MDEP-602] - Log dependency warnings as errors when failOnWarning is set

### DIFF
--- a/src/it/projects/analyze/verify.groovy
+++ b/src/it/projects/analyze/verify.groovy
@@ -17,13 +17,25 @@
  * under the License.
  */
 
-import java.io.*;
-
 File classFile = new File( basedir, "target/classes/Main.class" );
-
+assert classFile.exists();
 if ( !classFile.isFile() )
 {
     throw new Exception( "Build was not forked, class missing " + classFile );
 }
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String buildLog = file.getText( "UTF-8" );
+assert buildLog.contains( '[INFO] Used declared dependencies found:');
+assert buildLog.contains( '[INFO]    org.apache.maven:maven-artifact:jar:2.0.6:compile');
+assert buildLog.contains( '[INFO]    org.apache.maven:maven-model:jar:2.0.6:compile');
+assert buildLog.contains( '[WARNING] Used undeclared dependencies found:');
+assert buildLog.contains( '[WARNING]    org.apache.maven:maven-repository-metadata:jar:2.0.6:compile');
+assert buildLog.contains( '[WARNING]       class org.apache.maven.artifact.repository.metadata.Metadata');
+assert buildLog.contains( '[WARNING] Unused declared dependencies found:');
+assert buildLog.contains( '[WARNING]    org.apache.maven:maven-project:jar:2.0.6:compile');
+
 
 return true;

--- a/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/invoker.properties
+++ b/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.buildResult = failure
+invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/pom.xml
+++ b/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency</groupId>
+  <artifactId>mdep-602-log-on-error-level-when-failOnWarning</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <description>Test that dependency:analyze logs dependency warnings as errors when failOnWarning is set to true</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <failOnWarning>true</failOnWarning>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/src/main/java/Main.java
+++ b/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/src/main/java/Main.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+public class Main
+{
+}

--- a/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/verify.groovy
+++ b/src/it/projects/mdep-602-log-on-error-level-when-failOnWarning/verify.groovy
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String buildLog = file.getText( "UTF-8" );
+assert buildLog.contains( '[ERROR] Unused declared dependencies found:');
+assert buildLog.contains( '[ERROR]    org.apache.maven:maven-project:jar:2.0.6:compile' );
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -406,7 +406,7 @@ public abstract class AbstractAnalyzeMojo
 
         if ( !usedUndeclaredWithClasses.isEmpty() )
         {
-            getLog().warn( "Used undeclared dependencies found:" );
+            logDependencyWarning( "Used undeclared dependencies found:" );
 
             if ( verbose )
             {
@@ -422,7 +422,7 @@ public abstract class AbstractAnalyzeMojo
 
         if ( !unusedDeclared.isEmpty() )
         {
-            getLog().warn( "Unused declared dependencies found:" );
+            logDependencyWarning( "Unused declared dependencies found:" );
 
             logArtifacts( unusedDeclared, true );
             reported = true;
@@ -431,7 +431,7 @@ public abstract class AbstractAnalyzeMojo
 
         if ( !nonTestScope.isEmpty() )
         {
-            getLog().warn( "Non-test scoped test only dependencies found:" );
+            logDependencyWarning( "Non-test scoped test only dependencies found:" );
 
             logArtifacts( nonTestScope, true );
             reported = true;
@@ -500,7 +500,7 @@ public abstract class AbstractAnalyzeMojo
 
                 if ( warn )
                 {
-                    getLog().warn( "   " + artifact );
+                    logDependencyWarning( "   " + artifact );
                 }
                 else
                 {
@@ -526,10 +526,10 @@ public abstract class AbstractAnalyzeMojo
 
                 if ( warn )
                 {
-                    getLog().warn( "   " + entry.getKey() );
+                    logDependencyWarning( "   " + entry.getKey() );
                     for ( String clazz : entry.getValue() )
                     {
-                        getLog().warn( "      class " + clazz );
+                        logDependencyWarning( "      class " + clazz );
                     }
                 }
                 else
@@ -542,6 +542,18 @@ public abstract class AbstractAnalyzeMojo
                 }
 
             }
+        }
+    }
+
+    private void logDependencyWarning( CharSequence content )
+    {
+        if ( failOnWarning )
+        {
+            getLog().error( content );
+        }
+        else
+        {
+            getLog().warn( content );
         }
     }
 


### PR DESCRIPTION
As the ticket describes, having dependency warnings fail the build is somewhat unexpected to many developers. This change logs those warnings as errors when the `failOnWarning` parameter is set to true.

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
