### PR TITLE
move integration test to Java 1.8

### DIFF
--- a/src/it/projects/analyze-testDependencyWithNonTestScope/pom.xml
+++ b/src/it/projects/analyze-testDependencyWithNonTestScope/pom.xml
@@ -28,8 +28,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.release>1.7</maven.compiler.release>
-    <maven.compiler.sources>1.7</maven.compiler.sources>
+    <maven.compiler.release>1.8</maven.compiler.release>
+    <maven.compiler.sources>1.8</maven.compiler.sources>
   </properties>
 
   <build>


### PR DESCRIPTION
At least one of our CI environments has a problem compiling for Java 1.7:

 Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.10.1:compile (default-compile) on project nonTestScopeTestArtifactsAnalysis: Fatal error compiling: error: release version 1.7 not supported -> [Help 1]

I don't think this test is materially changed by updating it to Java 1.8. 