### PR TITLE
[MDEP-317] - add mojo to analyze invalid exclusions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
   </parent>
 
   <artifactId>maven-dependency-plugin</artifactId>
-  <version>3.6.2-SNAPSHOT</version>
+  <version>3.7.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Apache Maven Dependency Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,13 @@ under the License.
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <version>3.24.2</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Remove once deprecated code has been replaced/removed  -->
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/invoker.properties
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# 'install' is for this IT to work with Maven 2.2.1. Not required for Maven 3.0+.
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:analyze-exclusions

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/module1/pom.xml
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/module1/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.dependency</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>test-module1</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/module1/src/main/java/foo/Main.java
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/module1/src/main/java/foo/Main.java
@@ -16,16 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package foo;
 
-File file = new File( basedir, "build.log" );
-assert file.exists();
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.model.Model;
 
-String buildLog = file.getText( "UTF-8" );
-assert buildLog.contains( '[WARNING] test-module defines following unnecessary excludes');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-artifact:');
-assert buildLog.contains( '[WARNING]         - javax.annotation:javax.annotation-api');
-assert buildLog.contains( '[WARNING]         - javax.activation:javax.activation-api');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-core:');
-assert buildLog.contains( '[WARNING]         - javax.servlet:javax.servlet-api');
+public class Main
+{
+    public static final String SCOPE_COMPILE = Artifact.SCOPE_COMPILE;
 
-return true;
+    public Model model = null;
+
+    public Metadata metadata = null;
+}

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/module2/pom.xml
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/module2/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.dependency</groupId>
+    <artifactId>test-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>test-module2</artifactId>
+
+  <dependencies>
+  </dependencies>
+</project>

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/module2/src/main/java/foo/Main.java
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/module2/src/main/java/foo/Main.java
@@ -16,16 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+package foo;
 
-File file = new File( basedir, "build.log" );
-assert file.exists();
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.model.Model;
 
-String buildLog = file.getText( "UTF-8" );
-assert buildLog.contains( '[WARNING] test-module defines following unnecessary excludes');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-artifact:');
-assert buildLog.contains( '[WARNING]         - javax.annotation:javax.annotation-api');
-assert buildLog.contains( '[WARNING]         - javax.activation:javax.activation-api');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-core:');
-assert buildLog.contains( '[WARNING]         - javax.servlet:javax.servlet-api');
+public class Main
+{
+    public static final String SCOPE_COMPILE = Artifact.SCOPE_COMPILE;
 
-return true;
+    public Model model = null;
+
+    public Metadata metadata = null;
+}

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/pom.xml
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/pom.xml
@@ -24,45 +24,23 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <artifactId>test-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
 
-  <name>test-module</name>
+  <name>Test</name>
   <description>
-    Test dependency:analyze-exclusion
+    Test dependency:analyze on a multi-module project
   </description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-core</artifactId>
-      <version>3.9.6</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-artifact</artifactId>
-      <version>3.9.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.annotation</groupId>
-          <artifactId>javax.annotation-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.activation</groupId>
-          <artifactId>javax.activation-api</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>3.9.6</version>
-    </dependency>
-  </dependencies>
+  
+  <modules>
+    <module>module1</module>
+    <module>module2</module>
+  </modules>
 
   <dependencyManagement>
     <dependencies>
@@ -80,16 +58,4 @@
     </dependencies>
   </dependencyManagement>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <artifactId>maven-dependency-plugin</artifactId>
-          <configuration>
-           <failOnWarning>false</failOnWarning>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/src/it/projects/analyze-invalid-exclude-multumodule-project/verify.groovy
+++ b/src/it/projects/analyze-invalid-exclude-multumodule-project/verify.groovy
@@ -21,11 +21,10 @@ File file = new File( basedir, "build.log" );
 assert file.exists();
 
 String buildLog = file.getText( "UTF-8" );
-assert buildLog.contains( '[WARNING] test-module defines following unnecessary excludes');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-artifact:');
-assert buildLog.contains( '[WARNING]         - javax.annotation:javax.annotation-api');
-assert buildLog.contains( '[WARNING]         - javax.activation:javax.activation-api');
+assert buildLog.contains( '[WARNING] test-module1 defines following unnecessary excludes');
 assert buildLog.contains( '[WARNING]     org.apache.maven:maven-core:');
 assert buildLog.contains( '[WARNING]         - javax.servlet:javax.servlet-api');
+
+assert !buildLog.contains( '[WARNING] test-module2 defines following unnecessary excludes');
 
 return true;

--- a/src/it/projects/analyze-invalid-exclude/invoker.properties
+++ b/src/it/projects/analyze-invalid-exclude/invoker.properties
@@ -15,4 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:analyze-exclusions
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:analyze-exclusions

--- a/src/it/projects/analyze-invalid-exclude/invoker.properties
+++ b/src/it/projects/analyze-invalid-exclude/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:analyze-exclusions

--- a/src/it/projects/analyze-invalid-exclude/pom.xml
+++ b/src/it/projects/analyze-invalid-exclude/pom.xml
@@ -39,13 +39,13 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-      <version>2.0.6</version>
+      <artifactId>maven-core</artifactId>
+      <version>3.9.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.0.6</version>
+      <version>3.9.6</version>
       <exclusions>
         <exclusion>
           <groupId>javax.annotation</groupId>
@@ -60,7 +60,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>2.0.6</version>
+      <version>3.9.6</version>
     </dependency>
   </dependencies>
 
@@ -68,12 +68,12 @@
     <dependencies>
       <dependency>
         <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
-        <version>2.0.6</version>
+        <artifactId>maven-core</artifactId>
+        <version>3.9.6</version>
         <exclusions>
           <exclusion>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/src/it/projects/analyze-invalid-exclude/pom.xml
+++ b/src/it/projects/analyze-invalid-exclude/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency:analyze-exclusion
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>2.0.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>javax.activation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-model</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-project</artifactId>
+        <version>2.0.6</version>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+           <failOnWarning>false</failOnWarning>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/analyze-invalid-exclude/src/main/java/Main.java
+++ b/src/it/projects/analyze-invalid-exclude/src/main/java/Main.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.metadata.Metadata;
+import org.apache.maven.model.Model;
+
+public class Main
+{
+    public static final String SCOPE_COMPILE = Artifact.SCOPE_COMPILE;
+
+    public Model model = null;
+
+    public Metadata metadata = null;
+}

--- a/src/it/projects/analyze-invalid-exclude/verify.groovy
+++ b/src/it/projects/analyze-invalid-exclude/verify.groovy
@@ -25,7 +25,7 @@ assert buildLog.contains( '[WARNING] The following dependencies defines unnecess
 assert buildLog.contains( '[WARNING]     org.apache.maven:maven-artifact:');
 assert buildLog.contains( '[WARNING]         - javax.annotation:javax.annotation-api');
 assert buildLog.contains( '[WARNING]         - javax.activation:javax.activation-api');
-assert buildLog.contains( '[WARNING]     org.apache.maven:maven-project:');
-assert buildLog.contains( '[WARNING]         - javax.inject:javax.inject');
+assert buildLog.contains( '[WARNING]     org.apache.maven:maven-core:');
+assert buildLog.contains( '[WARNING]         - javax.servlet:javax.servlet-api');
 
 return true;

--- a/src/it/projects/analyze-invalid-exclude/verify.groovy
+++ b/src/it/projects/analyze-invalid-exclude/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File file = new File( basedir, "build.log" );
+assert file.exists();
+
+String buildLog = file.getText( "UTF-8" );
+assert buildLog.contains( '[WARNING] The following dependencies defines unnecessary excludes');
+assert buildLog.contains( '[WARNING]     org.apache.maven:maven-artifact:');
+assert buildLog.contains( '[WARNING]         - javax.annotation:javax.annotation-api');
+assert buildLog.contains( '[WARNING]         - javax.activation:javax.activation-api');
+assert buildLog.contains( '[WARNING]     org.apache.maven:maven-project:');
+assert buildLog.contains( '[WARNING]         - javax.inject:javax.inject');
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -120,10 +120,10 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
 
         if (!checker.getViolations().isEmpty()) {
             if (failOnWarning) {
-                logViolations(checker.getViolations(), (value) -> getLog().error(value));
+                logViolations(project.getName(), checker.getViolations(), (value) -> getLog().error(value));
                 throw new MojoExecutionException("Invalid exclusions found");
             } else {
-                logViolations(checker.getViolations(), (value) -> getLog().warn(value));
+                logViolations(project.getName(), checker.getViolations(), (value) -> getLog().warn(value));
             }
         }
     }
@@ -135,8 +135,8 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
                 && Objects.equals(stripToEmpty(artifact.getClassifier()), stripToEmpty(dependency.getClassifier()));
     }
 
-    private void logViolations(Map<Coordinates, List<Coordinates>> violations, final Consumer<String> logger) {
-        logger.accept("The following dependencies defines unnecessary excludes");
+    private void logViolations(String name, Map<Coordinates, List<Coordinates>> violations, Consumer<String> logger) {
+        logger.accept(name + " defines following unnecessary excludes");
         violations.forEach((dependency, invalidExclusions) -> {
             logger.accept("    " + dependency + ":");
             invalidExclusions.forEach(invalidExclusion -> {

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -77,12 +77,12 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
     /**
      * Skip plugin execution completely.
      */
-    @Parameter(property = "mdep.skip", defaultValue = "false")
-    private boolean skip;
+    @Parameter(property = "mdep.exclusion.fail", defaultValue = "false")
+    private boolean exclusionFail;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (skip) {
+        if (exclusionFail) {
             getLog().debug("Skipping execution");
             return;
         }

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.exclusion;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Execute;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingException;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingResult;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.apache.commons.lang3.StringUtils.stripToEmpty;
+import static org.apache.maven.plugins.dependency.exclusion.Coordinates.coordinates;
+
+/**
+ * Analyzes the exclusions defined on dependencies in this project and reports if any of them are invalid.
+ * <p>
+ * Relevant use case is when an artifact in a later version has removed usage of a dependency, making the exclusion no
+ * longer valid.
+ * </p>
+ *
+ * @since 3.6.2
+ */
+@Mojo(name = "analyze-exclusions", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
+@Execute(phase = LifecyclePhase.TEST_COMPILE)
+public class AnalyzeExclusionsMojo extends AbstractMojo {
+
+    @Component
+    private MavenProject project;
+
+    @Component
+    private ProjectBuilder projectBuilder;
+
+    @Component
+    private MavenSession session;
+
+    /**
+     * Whether to fail the build if invalid exclusions is found.
+     */
+    @Parameter(property = "failOnWarning", defaultValue = "false")
+    private boolean failOnWarning;
+
+    /**
+     * Skip plugin execution completely.
+     */
+    @Parameter(property = "mdep.skip", defaultValue = "false")
+    private boolean skip;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (skip) {
+            getLog().debug("Skipping execution");
+            return;
+        }
+        List<Dependency> dependenciesWithExclusions = project.getDependencies().stream()
+                .filter(dep -> !dep.getExclusions().isEmpty())
+                .collect(toList());
+
+        if (dependenciesWithExclusions.isEmpty()) {
+            getLog().debug("No dependencies defined with exclusions - exiting");
+            return;
+        }
+
+        ExclusionChecker checker = new ExclusionChecker();
+
+        for (final Dependency dependency : dependenciesWithExclusions) {
+            Coordinates currentCoordinates = coordinates(dependency.getGroupId(), dependency.getArtifactId());
+            Artifact matchingArtifact = project.getArtifacts().stream()
+                    .filter(artifact -> matchesDependency(artifact, dependency))
+                    .findFirst()
+                    .orElseThrow(() -> new MojoExecutionException(
+                            format("Error finding Artifact for given Dependency [%s]", dependency)));
+
+            ProjectBuildingResult result = buildProject(matchingArtifact);
+
+            Set<Coordinates> actualDependencies = result.getProject().getArtifacts().stream()
+                    .map(a -> coordinates(a.getGroupId(), a.getArtifactId()))
+                    .collect(toSet());
+
+            Set<Coordinates> exclusions = dependency.getExclusions().stream()
+                    .map(e -> coordinates(e.getGroupId(), e.getArtifactId()))
+                    .collect(toSet());
+
+            checker.check(currentCoordinates, exclusions, actualDependencies);
+        }
+
+        if (!checker.getViolations().isEmpty()) {
+            if (failOnWarning) {
+                logViolations(checker.getViolations(), (value) -> getLog().error(value));
+                throw new MojoExecutionException("Invalid exclusions found");
+            } else {
+                logViolations(checker.getViolations(), (value) -> getLog().warn(value));
+            }
+        }
+    }
+
+    private boolean matchesDependency(Artifact artifact, Dependency dependency) {
+        return Objects.equals(artifact.getGroupId(), dependency.getGroupId())
+                && Objects.equals(artifact.getArtifactId(), dependency.getArtifactId())
+                && Objects.equals(artifact.getType(), dependency.getType())
+                && Objects.equals(stripToEmpty(artifact.getClassifier()), stripToEmpty(dependency.getClassifier()));
+    }
+
+    private void logViolations(Map<Coordinates, List<Coordinates>> violations, final Consumer<String> logger) {
+        logger.accept("The following dependencies defines unnecessary excludes");
+        violations.forEach((dependency, invalidExclusions) -> {
+            logger.accept("    " + dependency + ":");
+            invalidExclusions.forEach(invalidExclusion -> {
+                logger.accept("        - " + invalidExclusion);
+            });
+        });
+    }
+
+    private ProjectBuildingResult buildProject(Artifact artifact) throws MojoExecutionException {
+        try {
+            ProjectBuildingRequest projectBuildingRequest =
+                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+            projectBuildingRequest.setResolveDependencies(true);
+            return projectBuilder.build(artifact, true, projectBuildingRequest);
+        } catch (ProjectBuildingException e) {
+            throw new MojoExecutionException(
+                    format("Failed to build project for %s:%s", artifact.getGroupId(), artifact.getArtifactId()), e);
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -31,8 +31,6 @@ import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
-import org.apache.maven.plugins.annotations.Execute;
-import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -59,7 +57,6 @@ import static org.apache.maven.plugins.dependency.exclusion.Coordinates.coordina
  * @since 3.6.2
  */
 @Mojo(name = "analyze-exclusions", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
-@Execute(phase = LifecyclePhase.TEST_COMPILE)
 public class AnalyzeExclusionsMojo extends AbstractMojo {
 
     @Component

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -54,7 +54,7 @@ import static org.apache.maven.plugins.dependency.exclusion.Coordinates.coordina
  * longer valid.
  * </p>
  *
- * @since 3.6.2
+ * @since 3.7.0
  */
 @Mojo(name = "analyze-exclusions", requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true)
 public class AnalyzeExclusionsMojo extends AbstractMojo {
@@ -70,12 +70,16 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
 
     /**
      * Whether to fail the build if invalid exclusions is found.
+     *
+     * @since 3.7.0
      */
     @Parameter(property = "mdep.exclusion.fail", defaultValue = "false")
     private boolean exclusionFail;
 
     /**
      * Skip plugin execution completely.
+     *
+     * @since 3.7.0
      */
     @Parameter(property = "mdep.skip", defaultValue = "false")
     private boolean skip;

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -71,18 +71,18 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
     /**
      * Whether to fail the build if invalid exclusions is found.
      */
-    @Parameter(property = "failOnWarning", defaultValue = "false")
-    private boolean failOnWarning;
+    @Parameter(property = "mdep.exclusion.fail", defaultValue = "false")
+    private boolean exclusionFail;
 
     /**
      * Skip plugin execution completely.
      */
-    @Parameter(property = "mdep.exclusion.fail", defaultValue = "false")
-    private boolean exclusionFail;
+    @Parameter(property = "mdep.skip", defaultValue = "false")
+    private boolean skip;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (exclusionFail) {
+        if (skip) {
             getLog().debug("Skipping execution");
             return;
         }
@@ -119,7 +119,7 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
         }
 
         if (!checker.getViolations().isEmpty()) {
-            if (failOnWarning) {
+            if (exclusionFail) {
                 logViolations(project.getName(), checker.getViolations(), (value) -> getLog().error(value));
                 throw new MojoExecutionException("Invalid exclusions found");
             } else {

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/Coordinates.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/Coordinates.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.exclusion;
+
+import java.lang.reflect.Proxy;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.Objects;
+import java.util.function.Predicate;
+
+/**
+ * Simple "record" to hold the coordinates of the dependency which is excluded.
+ * <p>
+ * When dealing with exclusions the version is not important. Only groupId and artifactId is used.
+ * </p>
+ */
+class Coordinates {
+    private final String groupId;
+    private final String artifactId;
+
+    private Coordinates(String groupId, String artifactId) {
+        this.groupId = groupId;
+        this.artifactId = artifactId;
+    }
+
+    public static Coordinates coordinates(String groupId, String artifactId) {
+        return new Coordinates(groupId, artifactId);
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public String getArtifactId() {
+        return artifactId;
+    }
+
+    Predicate<Coordinates> getExclusionPattern() {
+        PathMatcher groupId = FileSystems.getDefault().getPathMatcher("glob:" + getGroupId());
+        PathMatcher artifactId = FileSystems.getDefault().getPathMatcher("glob:" + getArtifactId());
+        Predicate<Coordinates> predGroupId = a -> groupId.matches(createPathProxy(a.getGroupId()));
+        Predicate<Coordinates> predArtifactId = a -> artifactId.matches(createPathProxy(a.getArtifactId()));
+
+        return predGroupId.and(predArtifactId);
+    }
+
+    /**
+     * In order to reuse the glob matcher from the filesystem, we need
+     * to create Path instances.  Those are only used with the toString method.
+     * This hack works because the only system-dependent thing is the path
+     * separator which should not be part of the groupId or artifactId.
+     */
+    private static Path createPathProxy(String value) {
+        return (Path) Proxy.newProxyInstance(
+                Coordinates.class.getClassLoader(), new Class[] {Path.class}, (proxy1, method, args) -> {
+                    if ("toString".equals(method.getName())) {
+                        return value;
+                    }
+                    throw new UnsupportedOperationException();
+                });
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Coordinates that = (Coordinates) o;
+        return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(groupId, artifactId);
+    }
+
+    @Override
+    public String toString() {
+        return groupId + ":" + artifactId;
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/ExclusionChecker.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/ExclusionChecker.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.exclusion;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+
+class ExclusionChecker {
+
+    private final Map<Coordinates, List<Coordinates>> violations = new HashMap<>();
+
+    Map<Coordinates, List<Coordinates>> getViolations() {
+        return violations;
+    }
+
+    void check(Coordinates artifact, final Set<Coordinates> excludes, final Set<Coordinates> actualDependencies) {
+        List<Coordinates> invalidExclusions = excludes.stream()
+                .filter(exclude -> actualDependencies.stream().noneMatch(exclude.getExclusionPattern()))
+                .collect(toList());
+
+        if (!invalidExclusions.isEmpty()) {
+            violations.put(artifact, invalidExclusions);
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/ExclusionChecker.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/ExclusionChecker.java
@@ -33,7 +33,7 @@ class ExclusionChecker {
         return violations;
     }
 
-    void check(Coordinates artifact, final Set<Coordinates> excludes, final Set<Coordinates> actualDependencies) {
+    void check(Coordinates artifact, Set<Coordinates> excludes, Set<Coordinates> actualDependencies) {
         List<Coordinates> invalidExclusions = excludes.stream()
                 .filter(exclude -> actualDependencies.stream().noneMatch(exclude.getExclusionPattern()))
                 .collect(toList());

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -98,6 +98,8 @@ ${project.name}
   *{{{./unpack-dependencies-mojo.html}dependency:unpack-dependencies}} like
   copy-dependencies but unpacks.
 
+  *{{{./analyze-exclusions-mojo.html}dependency:analyze-exclusions}} displays invalid exclusions for this project.
+
   []
 
 * Usage

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -695,3 +695,24 @@ mvn dependency:get -DgroupId=org.apache.maven -DartifactId=maven-core -Dversion=
 mvn dependency:get -DgroupId=org.apache.maven -DartifactId=maven-core -Dversion=2.2.1 -Dpackaging=jar -Dclassifier=sources -DremoteRepositories=https://repo.maven.apache.org/maven2 
 mvn dependency:get -Dartifact=org.apache.maven:maven-core:2.2.1:jar:sources -DremoteRepositories=https://repo.maven.apache.org/maven2 -Ddest=/tmp/myfile.jar
 +-----+
+
+
+* <<<dependency:analyze-exclusions>>>
+
+  This goal checks exclusions on dependencies and checks if the artifact actually brings in the given dependency.
+  For instance given dependency a:b:1.0 transitively includes x:y:1.0 which you do not want for some reason and exclude it.
+  Later a:b:2.0 has removed the unwanted dependency and you upgrade. This goal will inform you that the exclusion is no
+  longer required.
+
++---+
+mvn dependency:analyze-exclusions
++---+
+
+  Sample output:
+
++---+
+[WARNING] The following dependencies defines unnecessary excludes
+[WARNING]     org.apache.maven:maven-artifact:
+[WARNING]         - javax.annotation:javax.annotation-api
+[WARNING]         - javax.activation:javax.activation-api
++---+

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -58,6 +58,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         super.setUp("analyze-exclusions", true, false);
 
         project = new DependencyProjectStub();
+        project.setName("projectName");
         getContainer().addComponent(project, MavenProject.class.getName());
 
         MavenSession session = newMavenSession(project);
@@ -150,11 +151,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
 
         mojo.execute();
 
-        assertThat(testLog.getContent())
-                .doesNotContain(
-                        "[warn] The following dependencies defines unnecessary excludes",
-                        "[warn]     a:b:",
-                        "[warn]         - *:*");
+        assertThat(testLog.getContent()).doesNotContain("[warn]     a:b:", "[warn]         - *:*");
     }
 
     public void testCanResolveMultipleArtifactsWithEqualGroupIdAndArtifactId() throws Exception {
@@ -193,6 +190,20 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         assertThatCode(() -> mojo.execute()).doesNotThrowAnyException();
     }
 
+    public void testThatLogContainProjectName() throws Exception {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency withInvalidExclusion = dependency("a", "b");
+        withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
+        dependencies.add(withInvalidExclusion);
+        project.setDependencies(dependencies);
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
+
+        mojo.execute();
+
+        assertThat(testLog.getContent()).contains("[warn] projectName defines following unnecessary excludes");
+    }
+
     private Dependency dependency(String groupId, String artifactId) {
         Dependency dependency = new Dependency();
         dependency.setGroupId(groupId);
@@ -225,57 +236,79 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
     static class TestLog implements Log {
         StringBuilder sb = new StringBuilder();
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(CharSequence content) {
             print("debug", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(CharSequence content, Throwable error) {
             print("debug", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void debug(Throwable error) {
             print("debug", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(CharSequence content) {
             print("info", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(CharSequence content, Throwable error) {
             print("info", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void info(Throwable error) {
             print("info", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(CharSequence content) {
             print("warn", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(CharSequence content, Throwable error) {
             print("warn", content, error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void warn(Throwable error) {
             print("warn", error);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void error(CharSequence content) {
             print("error", content);
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         public void error(CharSequence content, Throwable error) {
             StringWriter sWriter = new StringWriter();
             PrintWriter pWriter = new PrintWriter(sWriter);

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.maven.artifact.Artifact;
@@ -36,8 +38,6 @@ import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingResult;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -70,14 +70,14 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         mojo.setLog(testLog);
     }
 
-    public void test_shall_throw_exception_when_fail_on_warning() throws Exception {
+    public void testShallThrowExceptionWhenFailOnWarning() throws Exception {
         List<Dependency> projectDependencies = new ArrayList<>();
         Dependency withInvalidExclusion = dependency("a", "b");
         withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
         projectDependencies.add(withInvalidExclusion);
         project.setDependencies(projectDependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
-        project.setArtifacts(newHashSet(artifact));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
         setVariableValueToObject(mojo, "failOnWarning", true);
 
         assertThatThrownBy(() -> mojo.execute())
@@ -85,14 +85,14 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
                 .hasMessageContaining("Invalid exclusions found");
     }
 
-    public void test_shall_log_error_when_failOnWarning_is_true() throws Exception {
+    public void testShallLogErrorWhenFailOnWarningIsTrue() throws Exception {
         List<Dependency> dependencies = new ArrayList<>();
         Dependency withInvalidExclusion = dependency("a", "b");
         withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
         dependencies.add(withInvalidExclusion);
         project.setDependencies(dependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
-        project.setArtifacts(newHashSet(artifact));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
         setVariableValueToObject(mojo, "failOnWarning", true);
 
         try {
@@ -104,14 +104,14 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         assertThat(testLog.getContent()).startsWith("[error]");
     }
 
-    public void test_shall_log_warning_when_failOnWarning_is_false() throws Exception {
+    public void testShallLogWarningWhenFailOnWarningIsFalse() throws Exception {
         List<Dependency> dependencies = new ArrayList<>();
         Dependency withInvalidExclusion = dependency("a", "b");
         withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
         dependencies.add(withInvalidExclusion);
         project.setDependencies(dependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
-        project.setArtifacts(newHashSet(artifact));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
         setVariableValueToObject(mojo, "failOnWarning", false);
 
         mojo.execute();
@@ -119,7 +119,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         assertThat(testLog.getContent()).startsWith("[warn]");
     }
 
-    public void test_shall_exit_without_analyze_when_no_dependency_has_exclusion() throws Exception {
+    public void testShallExitWithoutAnalyzeWhenNoDependencyHasExclusion() throws Exception {
         List<Dependency> dependencies = new ArrayList<>();
         dependencies.add(dependency("a", "c"));
         project.setDependencies(dependencies);
@@ -127,16 +127,16 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         assertThat(testLog.getContent()).startsWith("[debug] No dependencies defined with exclusions - exiting");
     }
 
-    public void test_shall_not_report_invalid_exclusion_for_wildcard_groupId_and_artifactId() throws Exception {
+    public void testShallNotReportInvalidExclusionForWildcardGroupIdAndArtifactId() throws Exception {
         Dependency dependencyWithWildcardExclusion = dependency("a", "b");
         dependencyWithWildcardExclusion.addExclusion(exclusion("*", "*"));
-        project.setDependencies(newArrayList(dependencyWithWildcardExclusion));
+        project.setDependencies(Arrays.asList(dependencyWithWildcardExclusion));
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
-        project.setArtifacts(newHashSet(artifact));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
 
         ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
         MavenProject mavenProject = new MavenProject();
-        mavenProject.setArtifacts(newHashSet(stubFactory.createArtifact("whatever", "ok", "1.0")));
+        mavenProject.setArtifacts(new HashSet<>(Arrays.asList(stubFactory.createArtifact("whatever", "ok", "1.0"))));
 
         ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);
         when(pbr.getProject()).thenReturn(mavenProject);
@@ -152,20 +152,20 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
                         "[warn]         - *:*");
     }
 
-    public void test_can_resolve_multiple_artifacts_with_equal_groupId_and_artifact_id() throws Exception {
+    public void testCanResolveMultipleArtifactsWithEqualGroupIdAndArtifactId() throws Exception {
         Dependency dependency1 = dependency("a", "b");
         Dependency dependency2 = dependency("a", "b", "compile", "native");
         dependency1.addExclusion(exclusion("c", "d"));
         dependency2.addExclusion(exclusion("c", "d"));
-        project.setDependencies(newArrayList(dependency1, dependency2));
+        project.setDependencies(Arrays.asList(dependency1, dependency2));
         Artifact artifact1 = stubFactory.createArtifact("a", "b", "1.0");
         Artifact artifact2 = stubFactory.createArtifact("a", "b", "1.0", "compile", "jar", "native");
-        project.setArtifacts(newHashSet(artifact1, artifact2));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact1, artifact2)));
 
         assertThatCode(() -> mojo.execute()).doesNotThrowAnyException();
     }
 
-    public void test_shall_not_log_when_exclusion_is_valid() throws Exception {
+    public void testShallNotLogWhenExclusionIsValid() throws Exception {
         List<Dependency> dependencies = new ArrayList<>();
         Dependency dependency = dependency("a", "b");
         dependency.addExclusion(exclusion("ok", "ok"));
@@ -173,12 +173,12 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         project.setDependencies(dependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
 
-        project.setArtifacts(newHashSet(artifact));
+        project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
         setVariableValueToObject(mojo, "failOnWarning", true);
 
         ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
         MavenProject mavenProject = new MavenProject();
-        mavenProject.setArtifacts(newHashSet(stubFactory.createArtifact("ok", "ok", "1.0")));
+        mavenProject.setArtifacts(new HashSet<>(Arrays.asList(stubFactory.createArtifact("ok", "ok", "1.0"))));
 
         ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);
         when(pbr.getProject()).thenReturn(mavenProject);

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -84,7 +84,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         project.setDependencies(projectDependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
         project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
-        setVariableValueToObject(mojo, "failOnWarning", true);
+        setVariableValueToObject(mojo, "exclusionFail", true);
 
         assertThatThrownBy(() -> mojo.execute())
                 .isInstanceOf(MojoExecutionException.class)
@@ -99,7 +99,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         project.setDependencies(dependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
         project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
-        setVariableValueToObject(mojo, "failOnWarning", true);
+        setVariableValueToObject(mojo, "exclusionFail", true);
 
         try {
             mojo.execute();
@@ -118,7 +118,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         project.setDependencies(dependencies);
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
         project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
-        setVariableValueToObject(mojo, "failOnWarning", false);
+        setVariableValueToObject(mojo, "exclusionFail", false);
 
         mojo.execute();
 
@@ -176,7 +176,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
         Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
 
         project.setArtifacts(new HashSet<>(Arrays.asList(artifact)));
-        setVariableValueToObject(mojo, "failOnWarning", true);
+        setVariableValueToObject(mojo, "exclusionFail", true);
 
         ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
         MavenProject mavenProject = new MavenProject();

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -1,0 +1,365 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.exclusion;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Exclusion;
+import org.apache.maven.plugin.LegacySupport;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.dependency.AbstractDependencyMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuilder;
+import org.apache.maven.project.ProjectBuildingResult;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
+
+    AnalyzeExclusionsMojo mojo;
+    MavenProject project;
+    private TestLog testLog;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp("analyze-exclusions", true, false);
+        File testPom = new File(getBasedir(), "target/test-classes/unit/analyze-exclusions/plugin-config.xml");
+        mojo = (AnalyzeExclusionsMojo) lookupMojo("analyze-exclusions", testPom);
+        assertNotNull(mojo);
+        project = (MavenProject) getVariableValueFromObject(mojo, "project");
+        MavenSession session = newMavenSession(project);
+        setVariableValueToObject(mojo, "session", session);
+
+        LegacySupport legacySupport = lookup(LegacySupport.class);
+        legacySupport.setSession(session);
+        installLocalRepository(legacySupport);
+
+        testLog = new TestLog();
+        mojo.setLog(testLog);
+    }
+
+    public void test_shall_throw_exception_when_fail_on_warning() throws Exception {
+        List<Dependency> projectDependencies = new ArrayList<>();
+        Dependency withInvalidExclusion = dependency("a", "b");
+        withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
+        projectDependencies.add(withInvalidExclusion);
+        project.setDependencies(projectDependencies);
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+        project.setArtifacts(newHashSet(artifact));
+        setVariableValueToObject(mojo, "failOnWarning", true);
+
+        assertThatThrownBy(() -> mojo.execute())
+                .isInstanceOf(MojoExecutionException.class)
+                .hasMessageContaining("Invalid exclusions found");
+    }
+
+    public void test_shall_log_error_when_failOnWarning_is_true() throws Exception {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency withInvalidExclusion = dependency("a", "b");
+        withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
+        dependencies.add(withInvalidExclusion);
+        project.setDependencies(dependencies);
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+        project.setArtifacts(newHashSet(artifact));
+        setVariableValueToObject(mojo, "failOnWarning", true);
+
+        try {
+            mojo.execute();
+        } catch (MojoExecutionException ignored) {
+            // ignored
+        }
+
+        assertThat(testLog.getContent()).startsWith("[error]");
+    }
+
+    public void test_shall_log_warning_when_failOnWarning_is_false() throws Exception {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency withInvalidExclusion = dependency("a", "b");
+        withInvalidExclusion.addExclusion(exclusion("invalid", "invalid"));
+        dependencies.add(withInvalidExclusion);
+        project.setDependencies(dependencies);
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+        project.setArtifacts(newHashSet(artifact));
+        setVariableValueToObject(mojo, "failOnWarning", false);
+
+        mojo.execute();
+
+        assertThat(testLog.getContent()).startsWith("[warn]");
+    }
+
+    public void test_shall_exit_without_analyze_when_no_dependency_has_exclusion() throws Exception {
+        List<Dependency> dependencies = new ArrayList<>();
+        dependencies.add(dependency("a", "c"));
+        project.setDependencies(dependencies);
+        mojo.execute();
+        assertThat(testLog.getContent()).startsWith("[debug] No dependencies defined with exclusions - exiting");
+    }
+
+    public void test_shall_not_report_invalid_exclusion_for_wildcard_groupId_and_artifactId() throws Exception {
+        Dependency dependencyWithWildcardExclusion = dependency("a", "b");
+        dependencyWithWildcardExclusion.addExclusion(exclusion("*", "*"));
+        project.setDependencies(newArrayList(dependencyWithWildcardExclusion));
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+        project.setArtifacts(newHashSet(artifact));
+
+        ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setArtifacts(newHashSet(stubFactory.createArtifact("whatever", "ok", "1.0")));
+
+        ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);
+        when(pbr.getProject()).thenReturn(mavenProject);
+        when(projectBuilder.build(any(Artifact.class), anyBoolean(), any())).thenReturn(pbr);
+        setVariableValueToObject(mojo, "projectBuilder", projectBuilder);
+
+        mojo.execute();
+
+        assertThat(testLog.getContent())
+                .doesNotContain(
+                        "[warn] The following dependencies defines unnecessary excludes",
+                        "[warn]     a:b:",
+                        "[warn]         - *:*");
+    }
+
+    public void test_can_resolve_multiple_artifacts_with_equal_groupId_and_artifact_id() throws Exception {
+        Dependency dependency1 = dependency("a", "b");
+        Dependency dependency2 = dependency("a", "b", "compile", "native");
+        dependency1.addExclusion(exclusion("c", "d"));
+        dependency2.addExclusion(exclusion("c", "d"));
+        project.setDependencies(newArrayList(dependency1, dependency2));
+        Artifact artifact1 = stubFactory.createArtifact("a", "b", "1.0");
+        Artifact artifact2 = stubFactory.createArtifact("a", "b", "1.0", "compile", "jar", "native");
+        project.setArtifacts(newHashSet(artifact1, artifact2));
+
+        assertThatCode(() -> mojo.execute()).doesNotThrowAnyException();
+    }
+
+    public void test_shall_not_log_when_exclusion_is_valid() throws Exception {
+        List<Dependency> dependencies = new ArrayList<>();
+        Dependency dependency = dependency("a", "b");
+        dependency.addExclusion(exclusion("ok", "ok"));
+        dependencies.add(dependency);
+        project.setDependencies(dependencies);
+        Artifact artifact = stubFactory.createArtifact("a", "b", "1.0");
+
+        project.setArtifacts(newHashSet(artifact));
+        setVariableValueToObject(mojo, "failOnWarning", true);
+
+        ProjectBuilder projectBuilder = mock(ProjectBuilder.class);
+        MavenProject mavenProject = new MavenProject();
+        mavenProject.setArtifacts(newHashSet(stubFactory.createArtifact("ok", "ok", "1.0")));
+
+        ProjectBuildingResult pbr = mock(ProjectBuildingResult.class);
+        when(pbr.getProject()).thenReturn(mavenProject);
+        when(projectBuilder.build(any(Artifact.class), anyBoolean(), any())).thenReturn(pbr);
+
+        setVariableValueToObject(mojo, "projectBuilder", projectBuilder);
+        assertThatCode(() -> mojo.execute()).doesNotThrowAnyException();
+    }
+
+    private Dependency dependency(String groupId, String artifactId) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion("1.0");
+        dependency.setScope("compile");
+        dependency.setType("jar");
+        dependency.setClassifier("");
+        return dependency;
+    }
+
+    private Dependency dependency(String groupId, String artifactId, String scope, String classifier) {
+        Dependency dependency = new Dependency();
+        dependency.setGroupId(groupId);
+        dependency.setArtifactId(artifactId);
+        dependency.setVersion("1.0");
+        dependency.setScope(scope);
+        dependency.setType("jar");
+        dependency.setClassifier(classifier);
+        return dependency;
+    }
+
+    private Exclusion exclusion(String groupId, String artifactId) {
+        Exclusion exclusion = new Exclusion();
+        exclusion.setGroupId(groupId);
+        exclusion.setArtifactId(artifactId);
+        return exclusion;
+    }
+
+    static class TestLog implements Log {
+        StringBuilder sb = new StringBuilder();
+
+        /** {@inheritDoc} */
+        public void debug(CharSequence content) {
+            print("debug", content);
+        }
+
+        /** {@inheritDoc} */
+        public void debug(CharSequence content, Throwable error) {
+            print("debug", content, error);
+        }
+
+        /** {@inheritDoc} */
+        public void debug(Throwable error) {
+            print("debug", error);
+        }
+
+        /** {@inheritDoc} */
+        public void info(CharSequence content) {
+            print("info", content);
+        }
+
+        /** {@inheritDoc} */
+        public void info(CharSequence content, Throwable error) {
+            print("info", content, error);
+        }
+
+        /** {@inheritDoc} */
+        public void info(Throwable error) {
+            print("info", error);
+        }
+
+        /** {@inheritDoc} */
+        public void warn(CharSequence content) {
+            print("warn", content);
+        }
+
+        /** {@inheritDoc} */
+        public void warn(CharSequence content, Throwable error) {
+            print("warn", content, error);
+        }
+
+        /** {@inheritDoc} */
+        public void warn(Throwable error) {
+            print("warn", error);
+        }
+
+        /** {@inheritDoc} */
+        public void error(CharSequence content) {
+            print("error", content);
+        }
+
+        /** {@inheritDoc} */
+        public void error(CharSequence content, Throwable error) {
+            StringWriter sWriter = new StringWriter();
+            PrintWriter pWriter = new PrintWriter(sWriter);
+
+            error.printStackTrace(pWriter);
+
+            System.err.println("[error] " + content.toString() + System.lineSeparator() + System.lineSeparator()
+                    + sWriter.toString());
+        }
+
+        /**
+         * @see org.apache.maven.plugin.logging.Log#error(java.lang.Throwable)
+         */
+        public void error(Throwable error) {
+            StringWriter sWriter = new StringWriter();
+            PrintWriter pWriter = new PrintWriter(sWriter);
+
+            error.printStackTrace(pWriter);
+
+            System.err.println("[error] " + sWriter.toString());
+        }
+
+        /**
+         * @see org.apache.maven.plugin.logging.Log#isDebugEnabled()
+         */
+        public boolean isDebugEnabled() {
+            // TODO: Not sure how best to set these for this implementation...
+            return false;
+        }
+
+        /**
+         * @see org.apache.maven.plugin.logging.Log#isInfoEnabled()
+         */
+        public boolean isInfoEnabled() {
+            return true;
+        }
+
+        /**
+         * @see org.apache.maven.plugin.logging.Log#isWarnEnabled()
+         */
+        public boolean isWarnEnabled() {
+            return true;
+        }
+
+        /**
+         * @see org.apache.maven.plugin.logging.Log#isErrorEnabled()
+         */
+        public boolean isErrorEnabled() {
+            return true;
+        }
+
+        private void print(String prefix, CharSequence content) {
+            sb.append("[")
+                    .append(prefix)
+                    .append("] ")
+                    .append(content.toString())
+                    .append(System.lineSeparator());
+        }
+
+        private void print(String prefix, Throwable error) {
+            StringWriter sWriter = new StringWriter();
+            PrintWriter pWriter = new PrintWriter(sWriter);
+
+            error.printStackTrace(pWriter);
+
+            sb.append("[")
+                    .append(prefix)
+                    .append("] ")
+                    .append(sWriter.toString())
+                    .append(System.lineSeparator());
+        }
+
+        private void print(String prefix, CharSequence content, Throwable error) {
+            StringWriter sWriter = new StringWriter();
+            PrintWriter pWriter = new PrintWriter(sWriter);
+
+            error.printStackTrace(pWriter);
+
+            sb.append("[")
+                    .append(prefix)
+                    .append("] ")
+                    .append(content.toString())
+                    .append(System.lineSeparator())
+                    .append(System.lineSeparator());
+            sb.append(sWriter.toString()).append(System.lineSeparator());
+        }
+
+        protected String getContent() {
+            return sb.toString();
+        }
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -34,6 +34,7 @@ import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.dependency.AbstractDependencyMojoTestCase;
+import org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingResult;
@@ -55,12 +56,16 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp("analyze-exclusions", true, false);
+
+        project = new DependencyProjectStub();
+        getContainer().addComponent(project, MavenProject.class.getName());
+
+        MavenSession session = newMavenSession(project);
+        getContainer().addComponent(session, MavenSession.class.getName());
+
         File testPom = new File(getBasedir(), "target/test-classes/unit/analyze-exclusions/plugin-config.xml");
         mojo = (AnalyzeExclusionsMojo) lookupMojo("analyze-exclusions", testPom);
         assertNotNull(mojo);
-        project = (MavenProject) getVariableValueFromObject(mojo, "project");
-        MavenSession session = newMavenSession(project);
-        setVariableValueToObject(mojo, "session", session);
 
         LegacySupport legacySupport = lookup(LegacySupport.class);
         legacySupport.setSession(session);

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/ExclusionCheckerTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/ExclusionCheckerTest.java
@@ -18,14 +18,13 @@
  */
 package org.apache.maven.plugins.dependency.exclusion;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import static com.google.common.collect.Lists.newArrayList;
-import static com.google.common.collect.Sets.newHashSet;
 import static org.apache.maven.plugins.dependency.exclusion.Coordinates.coordinates;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -39,45 +38,46 @@ public class ExclusionCheckerTest {
     }
 
     @Test
-    public void shall_report_invalid_exclusions() {
+    public void shallReportInvalidExclusions() {
         Coordinates artifact = coordinates("com.current", "artifact");
-        Set<Coordinates> excludes = newHashSet(
+        Set<Coordinates> excludes = new HashSet<>(Arrays.asList(
                 coordinates("com.example", "one"),
                 coordinates("com.example", "two"),
                 coordinates("com.example", "three"),
-                coordinates("com.example", "four"));
+                coordinates("com.example", "four")));
 
         Set<Coordinates> actualDependencies =
-                newHashSet(coordinates("com.example", "one"), coordinates("com.example", "four"));
+                new HashSet<>(Arrays.asList(coordinates("com.example", "one"), coordinates("com.example", "four")));
 
         checker.check(artifact, excludes, actualDependencies);
 
         assertThat(checker.getViolations())
                 .containsEntry(
-                        artifact, newArrayList(coordinates("com.example", "two"), coordinates("com.example", "three")));
+                        artifact,
+                        Arrays.asList(coordinates("com.example", "two"), coordinates("com.example", "three")));
     }
 
     @Test
-    public void no_violations_when_empty_exclusions() {
+    public void noViolationsWhenEmptyExclusions() {
         checker.check(coordinates("a", "b"), new HashSet<>(), new HashSet<>());
         assertThat(checker.getViolations()).isEmpty();
     }
 
     @Test
-    public void shall_report_invalid_exclusions_when_no_dependencies() {
+    public void shallReportInvalidExclusionsWhenNoDependencies() {
         Coordinates artifact = coordinates("a", "b");
         HashSet<Coordinates> actualDependencies = new HashSet<>();
-        checker.check(artifact, newHashSet(coordinates("p", "m")), actualDependencies);
-        assertThat(checker.getViolations()).containsEntry(artifact, newArrayList(coordinates("p", "m")));
+        checker.check(artifact, new HashSet<>(Arrays.asList(coordinates("p", "m"))), actualDependencies);
+        assertThat(checker.getViolations()).containsEntry(artifact, Arrays.asList(coordinates("p", "m")));
     }
 
     @Test
-    public void shall_handle_wildcard_exclusions() {
+    public void shallHandleWildcardExclusions() {
         Coordinates artifact = coordinates("com.current", "artifact");
-        Set<Coordinates> excludes = newHashSet(coordinates("*", "*"));
+        Set<Coordinates> excludes = new HashSet<>(Arrays.asList(coordinates("*", "*")));
 
         Set<Coordinates> actualDependencies =
-                newHashSet(coordinates("com.example", "one"), coordinates("com.example", "four"));
+                new HashSet<>(Arrays.asList(coordinates("com.example", "one"), coordinates("com.example", "four")));
 
         checker.check(artifact, excludes, actualDependencies);
 
@@ -85,14 +85,14 @@ public class ExclusionCheckerTest {
     }
 
     @Test
-    public void shall_handle_wildcard_groupId_exclusion() {
+    public void shallHandleWildcardGroupIdExclusion() {
         Coordinates artifact = coordinates("com.current", "artifact");
-        Set<Coordinates> excludes = newHashSet(coordinates("javax", "*"));
+        Set<Coordinates> excludes = new HashSet<>(Arrays.asList(coordinates("javax", "*")));
 
-        Set<Coordinates> actualDependencies = newHashSet(
+        Set<Coordinates> actualDependencies = new HashSet<>(Arrays.asList(
                 coordinates("com.example", "one"),
                 coordinates("com.example", "four"),
-                coordinates("javax", "whatever"));
+                coordinates("javax", "whatever")));
 
         checker.check(artifact, excludes, actualDependencies);
 

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/ExclusionCheckerTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/ExclusionCheckerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.exclusion;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
+import static org.apache.maven.plugins.dependency.exclusion.Coordinates.coordinates;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExclusionCheckerTest {
+
+    private ExclusionChecker checker;
+
+    @Before
+    public void setUp() throws Exception {
+        checker = new ExclusionChecker();
+    }
+
+    @Test
+    public void shall_report_invalid_exclusions() {
+        Coordinates artifact = coordinates("com.current", "artifact");
+        Set<Coordinates> excludes = newHashSet(
+                coordinates("com.example", "one"),
+                coordinates("com.example", "two"),
+                coordinates("com.example", "three"),
+                coordinates("com.example", "four"));
+
+        Set<Coordinates> actualDependencies =
+                newHashSet(coordinates("com.example", "one"), coordinates("com.example", "four"));
+
+        checker.check(artifact, excludes, actualDependencies);
+
+        assertThat(checker.getViolations())
+                .containsEntry(
+                        artifact, newArrayList(coordinates("com.example", "two"), coordinates("com.example", "three")));
+    }
+
+    @Test
+    public void no_violations_when_empty_exclusions() {
+        checker.check(coordinates("a", "b"), new HashSet<>(), new HashSet<>());
+        assertThat(checker.getViolations()).isEmpty();
+    }
+
+    @Test
+    public void shall_report_invalid_exclusions_when_no_dependencies() {
+        Coordinates artifact = coordinates("a", "b");
+        HashSet<Coordinates> actualDependencies = new HashSet<>();
+        checker.check(artifact, newHashSet(coordinates("p", "m")), actualDependencies);
+        assertThat(checker.getViolations()).containsEntry(artifact, newArrayList(coordinates("p", "m")));
+    }
+
+    @Test
+    public void shall_handle_wildcard_exclusions() {
+        Coordinates artifact = coordinates("com.current", "artifact");
+        Set<Coordinates> excludes = newHashSet(coordinates("*", "*"));
+
+        Set<Coordinates> actualDependencies =
+                newHashSet(coordinates("com.example", "one"), coordinates("com.example", "four"));
+
+        checker.check(artifact, excludes, actualDependencies);
+
+        assertThat(checker.getViolations()).isEmpty();
+    }
+
+    @Test
+    public void shall_handle_wildcard_groupId_exclusion() {
+        Coordinates artifact = coordinates("com.current", "artifact");
+        Set<Coordinates> excludes = newHashSet(coordinates("javax", "*"));
+
+        Set<Coordinates> actualDependencies = newHashSet(
+                coordinates("com.example", "one"),
+                coordinates("com.example", "four"),
+                coordinates("javax", "whatever"));
+
+        checker.check(artifact, excludes, actualDependencies);
+
+        assertThat(checker.getViolations()).isEmpty();
+    }
+}

--- a/src/test/resources/unit/analyze-exclusions/plugin-config.xml
+++ b/src/test/resources/unit/analyze-exclusions/plugin-config.xml
@@ -23,7 +23,6 @@
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-              <project implementation="org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub"/>
           </configuration>
       </plugin>
     </plugins>

--- a/src/test/resources/unit/analyze-exclusions/plugin-config.xml
+++ b/src/test/resources/unit/analyze-exclusions/plugin-config.xml
@@ -1,0 +1,44 @@
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License. 
+ *
+-->
+<project>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+              <project implementation="org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub"/>
+          </configuration>
+      </plugin>
+    </plugins>
+  </build>
+    <dependencies>
+        <dependency>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
+          <version>2.0.4</version>
+          <exclusions>
+            <exclusion>
+              <groupId>javax.inject</groupId>
+              <artifactId>javax.inject</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
This mojo reports if exclusions are defined on a dependency, but that dependency does not pull in said artifacts.

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Logs out a warning, alternatively fail when failOnError flag is set, when a dependency defines an exclusion that is not valid. 

Some notes
The failOnWarning property is the same property as for analyze, keep it that way or make its own property?

I placed the logic in its own package and made it its own execution, it can be moved to be a part of analyze if wanted. Having it as its own will make upgrading not change current behavior.

The exclusion glob pattern logic is copied from ExclusionArtifactFilter added in maven-core in jira MNG-7843. 