### PR TITLE
[MDEP-919] Try to fix a list-repositories for Maven 4

### DIFF
--- a/src/it/projects/list-repositories/verify.groovy
+++ b/src/it/projects/list-repositories/verify.groovy
@@ -24,5 +24,7 @@ String buildLog = file.getText( "UTF-8" )
 assert buildLog.contains( 'Project remote repositories used by this build:')
 assert buildLog.contains( '* fake-remote-repository (http://localhost:2345, default, releases+snapshots)')
 assert buildLog.contains( '* sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots, default, snapshots) mirrored by mrm-maven-plugin')
-assert buildLog.contains( '* central (https://repo.maven.apache.org/maven2, default, releases) mirrored by mrm-maven-plugin')
-
+// should I do it ...
+// if (!mavenVersion.startsWith('4.')) {
+assert buildLog.contains('* central (https://repo.maven.apache.org/maven2, default, releases) mirrored by mrm-maven-plugin')
+//}

--- a/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
@@ -89,6 +89,7 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
                 @Override
                 public boolean visitEnter(DependencyNode node) {
                     repositories.addAll(node.getRepositories());
+                    debugLogNodeRepo(node);
                     return true;
                 }
 
@@ -119,6 +120,22 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
         } catch (DependencyCollectionException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
+    }
+
+    private void debugLogNodeRepo(DependencyNode node) {
+        if (!getLog().isDebugEnabled()) {
+            return;
+        }
+
+        getLog().debug("Node: " + node + " resolved from:");
+        node.getRepositories().forEach(repo -> {
+            if (repo.getMirroredRepositories().isEmpty()) {
+                getLog().debug(" - " + repo);
+            } else {
+                getLog().debug(" - " + repo + " as mirror for:");
+                repo.getMirroredRepositories().forEach(mrepo -> getLog().debug("    - " + mrepo));
+            }
+        });
     }
 
     private void prepareRemoteMirrorRepositoriesList(


### PR DESCRIPTION
In debug ...

Maven 3.9.6

```
[DEBUG] Node: org.apache.maven.its.dependency:test:jar:1.0-SNAPSHOT resolved from:
[DEBUG]  - mrm-maven-plugin (http://localhost:55888, default, releases+snapshots) as mirror for:
[DEBUG]     - snapshots (http://localhost:55888, default, releases+snapshots)
[DEBUG]     - central (https://repo.maven.apache.org/maven2, default, releases)
[DEBUG]  - fake-remote-repository (http://localhost:2345, default, releases+snapshots)
```

Maven 4 (41d1950a6d8d88416ca7a34f82fbdf24bbafd9eb) I have:

```
[DEBUG] Node: org.apache.maven.its.dependency:test:jar:1.0-SNAPSHOT resolved from:
[DEBUG]  - mrm-maven-plugin (http://localhost:55825, default, releases+snapshots) as mirror for:
[DEBUG]     - snapshots (http://localhost:55825, default, releases+snapshots)
[DEBUG]  - fake-remote-repository (http://localhost:2345, default, releases+snapshots)
```

`central` is missing ...

What I should check, what debug ... @cstamas, @gnodet 



