### PR TITLE
[MDEP-923] Extract copyFile method from AbstractDependencyMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AbstractDependencyMojo.java
@@ -18,8 +18,6 @@
  */
 package org.apache.maven.plugins.dependency;
 
-import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -33,7 +31,6 @@ import org.apache.maven.plugins.dependency.utils.DependencySilentLog;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.codehaus.plexus.util.FileUtils;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -95,14 +92,6 @@ public abstract class AbstractDependencyMojo extends AbstractMojo {
     private boolean silent;
 
     /**
-     * Output absolute filename for resolved artifacts
-     *
-     * @since 2.0
-     */
-    @Parameter(property = "outputAbsoluteArtifactFilename", defaultValue = "false")
-    protected boolean outputAbsoluteArtifactFilename;
-
-    /**
      * Skip plugin execution completely.
      *
      * @since 2.7
@@ -130,32 +119,6 @@ public abstract class AbstractDependencyMojo extends AbstractMojo {
      * @throws MojoFailureException {@link MojoFailureException}
      */
     protected abstract void doExecute() throws MojoExecutionException, MojoFailureException;
-
-    /**
-     * Does the actual copy of the file and logging.
-     *
-     * @param artifact represents the file to copy.
-     * @param destFile file name of destination file.
-     * @throws MojoExecutionException with a message if an error occurs.
-     */
-    protected void copyFile(File artifact, File destFile) throws MojoExecutionException {
-        try {
-            getLog().info("Copying "
-                    + (this.outputAbsoluteArtifactFilename ? artifact.getAbsolutePath() : artifact.getName()) + " to "
-                    + destFile);
-
-            if (artifact.isDirectory()) {
-                // usual case is a future jar packaging, but there are special cases: classifier and other packaging
-                throw new MojoExecutionException("Artifact has not been packaged yet. When used on reactor artifact, "
-                        + "copy should be executed after packaging: see MDEP-187.");
-            }
-
-            FileUtils.copyFile(artifact, destFile);
-            buildContext.refresh(destFile);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Error copying artifact from " + artifact + " to " + destFile, e);
-        }
-    }
 
     /**
      * @return Returns a new ProjectBuildingRequest populated from the current session and the current project remote

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -23,9 +23,12 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.dependency.utils.CopyUtil;
 import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
 import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
 
@@ -38,6 +41,8 @@ import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
 @Mojo(name = "copy", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = false, threadSafe = true)
 public class CopyMojo extends AbstractFromConfigurationMojo {
 
+    @Component
+    private CopyUtil copyUtil;
     /**
      * Strip artifact version during copy
      */
@@ -109,12 +114,12 @@ public class CopyMojo extends AbstractFromConfigurationMojo {
      *
      * @param artifactItem containing the information about the Artifact to copy.
      * @throws MojoExecutionException with a message if an error occurs.
-     * @see #copyFile(File, File)
+     * @see CopyUtil#copyFile(Log, File, File)
      */
     protected void copyArtifact(ArtifactItem artifactItem) throws MojoExecutionException {
         File destFile = new File(artifactItem.getOutputDirectory(), artifactItem.getDestFileName());
 
-        copyFile(artifactItem.getArtifact().getFile(), destFile);
+        copyUtil.copyFile(getLog(), artifactItem.getArtifact().getFile(), destFile);
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -115,13 +114,13 @@ public class CopyMojo extends AbstractFromConfigurationMojo {
      *
      * @param artifactItem containing the information about the Artifact to copy.
      * @throws MojoExecutionException with a message if an error occurs.
-     * @see CopyUtil#copyFile(Log, File, File)
+     * @see CopyUtil#copyFile(File, File)
      */
     protected void copyArtifact(ArtifactItem artifactItem) throws MojoExecutionException {
         File destFile = new File(artifactItem.getOutputDirectory(), artifactItem.getDestFileName());
 
         try {
-            copyUtil.copyFile(getLog(), artifactItem.getArtifact().getFile(), destFile);
+            copyUtil.copyFile(artifactItem.getArtifact().getFile(), destFile);
         } catch (IOException e) {
             throw new MojoExecutionException(
                     "Failed copy " + artifactItem.getArtifact().getFile() + " to " + destFile, e);

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugins.dependency.fromConfiguration;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -119,7 +120,12 @@ public class CopyMojo extends AbstractFromConfigurationMojo {
     protected void copyArtifact(ArtifactItem artifactItem) throws MojoExecutionException {
         File destFile = new File(artifactItem.getOutputDirectory(), artifactItem.getDestFileName());
 
-        copyUtil.copyFile(getLog(), artifactItem.getArtifact().getFile(), destFile);
+        try {
+            copyUtil.copyFile(getLog(), artifactItem.getArtifact().getFile(), destFile);
+        } catch (IOException e) {
+            throw new MojoExecutionException(
+                    "Failed copy " + artifactItem.getArtifact().getFile() + " to " + destFile, e);
+        }
     }
 
     @Override

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
@@ -26,11 +26,13 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.dependency.utils.CopyUtil;
 import org.apache.maven.plugins.dependency.utils.DependencyStatusSets;
 import org.apache.maven.plugins.dependency.utils.DependencyUtil;
 import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
@@ -62,6 +64,9 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
      */
     @Parameter(property = "mdep.copyPom", defaultValue = "false")
     protected boolean copyPom = true;
+
+    @Component
+    private CopyUtil copyUtil;
 
     /**
      *
@@ -202,7 +207,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
      * @param theUseBaseVersion specifies if the baseVersion of the artifact should be used instead of the version.
      * @param removeClassifier specifies if the classifier should be removed from the file name when copying.
      * @throws MojoExecutionException with a message if an error occurs.
-     * @see #copyFile(File, File)
+     * @see CopyUtil#copyFile(Log, File, File)
      * @see DependencyUtil#getFormattedOutputDirectory(boolean, boolean, boolean, boolean, boolean, boolean, File, Artifact)
      */
     protected void copyArtifact(
@@ -227,7 +232,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                 artifact);
         File destFile = new File(destDir, destFileName);
 
-        copyFile(artifact.getFile(), destFile);
+        copyUtil.copyFile(getLog(), artifact.getFile(), destFile);
     }
 
     /**
@@ -267,7 +272,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                         DependencyUtil.getFormattedFileName(
                                 pomArtifact, removeVersion, prependGroupId, useBaseVersion, removeClassifier));
                 if (!pomDestFile.exists()) {
-                    copyFile(pomArtifact.getFile(), pomDestFile);
+                    copyUtil.copyFile(getLog(), pomArtifact.getFile(), pomDestFile);
                 }
             }
         }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
@@ -19,6 +19,7 @@
 package org.apache.maven.plugins.dependency.fromDependencies;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -232,7 +233,11 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                 artifact);
         File destFile = new File(destDir, destFileName);
 
-        copyUtil.copyFile(getLog(), artifact.getFile(), destFile);
+        try {
+            copyUtil.copyFile(getLog(), artifact.getFile(), destFile);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed copy " + artifact.getFile() + " to " + destFile, e);
+        }
     }
 
     /**
@@ -272,7 +277,12 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                         DependencyUtil.getFormattedFileName(
                                 pomArtifact, removeVersion, prependGroupId, useBaseVersion, removeClassifier));
                 if (!pomDestFile.exists()) {
-                    copyUtil.copyFile(getLog(), pomArtifact.getFile(), pomDestFile);
+                    try {
+                        copyUtil.copyFile(getLog(), pomArtifact.getFile(), pomDestFile);
+                    } catch (IOException e) {
+                        throw new MojoExecutionException(
+                                "Failed copy " + pomArtifact.getFile() + " to " + pomDestFile, e);
+                    }
                 }
             }
         }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -208,7 +207,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
      * @param theUseBaseVersion specifies if the baseVersion of the artifact should be used instead of the version.
      * @param removeClassifier specifies if the classifier should be removed from the file name when copying.
      * @throws MojoExecutionException with a message if an error occurs.
-     * @see CopyUtil#copyFile(Log, File, File)
+     * @see CopyUtil#copyFile(File, File)
      * @see DependencyUtil#getFormattedOutputDirectory(boolean, boolean, boolean, boolean, boolean, boolean, File, Artifact)
      */
     protected void copyArtifact(
@@ -234,7 +233,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
         File destFile = new File(destDir, destFileName);
 
         try {
-            copyUtil.copyFile(getLog(), artifact.getFile(), destFile);
+            copyUtil.copyFile(artifact.getFile(), destFile);
         } catch (IOException e) {
             throw new MojoExecutionException("Failed copy " + artifact.getFile() + " to " + destFile, e);
         }
@@ -278,7 +277,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                                 pomArtifact, removeVersion, prependGroupId, useBaseVersion, removeClassifier));
                 if (!pomDestFile.exists()) {
                     try {
-                        copyUtil.copyFile(getLog(), pomArtifact.getFile(), pomDestFile);
+                        copyUtil.copyFile(pomArtifact.getFile(), pomDestFile);
                     } catch (IOException e) {
                         throw new MojoExecutionException(
                                 "Failed copy " + pomArtifact.getFile() + " to " + pomDestFile, e);

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
@@ -71,6 +71,14 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
     protected boolean outputScope;
 
     /**
+     * Output absolute filename for resolved artifacts
+     *
+     * @since 2.0
+     */
+    @Parameter(property = "outputAbsoluteArtifactFilename", defaultValue = "false")
+    private boolean outputAbsoluteArtifactFilename;
+
+    /**
      * Only used to store results for integration test validation
      */
     DependencyStatusSets results;

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
@@ -50,6 +50,14 @@ public class ResolvePluginsMojo extends AbstractResolveMojo {
     private String outputEncoding;
 
     /**
+     * Output absolute filename for resolved artifacts
+     *
+     * @since 2.0
+     */
+    @Parameter(property = "outputAbsoluteArtifactFilename", defaultValue = "false")
+    private boolean outputAbsoluteArtifactFilename;
+
+    /**
      * Main entry into mojo. Gets the list of dependencies and iterates through displaying the resolved version.
      *
      * @throws MojoExecutionException with a message if an error occurs.

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.utils;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.codehaus.plexus.util.FileUtils;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Provide a copyFile method in one place.
+ */
+@Named
+@Singleton
+public class CopyUtil {
+
+    private final BuildContext buildContext;
+
+    @Inject
+    public CopyUtil(BuildContext buildContext) {
+        this.buildContext = buildContext;
+    }
+
+    /**
+     * Does the actual copy of the file and logging.
+     *
+     * @param source represents the file to copy.
+     * @param destination file name of destination file.
+     * @throws MojoExecutionException with a message if an error occurs.
+     */
+    public void copyFile(Log log, File source, File destination) throws MojoExecutionException {
+        try {
+            log.info("Copying " + source + " to " + destination);
+
+            if (source.isDirectory()) {
+                // usual case is a future jar packaging, but there are special cases: classifier and other packaging
+                throw new MojoExecutionException("Artifact has not been packaged yet. When used on reactor artifact, "
+                        + "copy should be executed after packaging: see MDEP-187.");
+            }
+
+            FileUtils.copyFile(source, destination);
+            buildContext.refresh(destination);
+        } catch (IOException e) {
+            throw new MojoExecutionException("Error copying artifact from " + source + " to " + destination, e);
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
@@ -33,6 +33,8 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
  * Provide a copyFile method in one place.
+ *
+ * @since 3.7.0
  */
 @Named
 @Singleton
@@ -53,6 +55,8 @@ public class CopyUtil {
      * @param source represents the file to copy.
      * @param destination file name of destination file.
      * @throws IOException with a message if an error occurs.
+     *
+     * @since 3.7.0
      */
     public void copyFile(File source, File destination) throws IOException, MojoExecutionException {
         logger.info("Copying {} to {}", source, destination);

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
@@ -49,22 +49,18 @@ public class CopyUtil {
      *
      * @param source represents the file to copy.
      * @param destination file name of destination file.
-     * @throws MojoExecutionException with a message if an error occurs.
+     * @throws IOException with a message if an error occurs.
      */
-    public void copyFile(Log log, File source, File destination) throws MojoExecutionException {
-        try {
-            log.info("Copying " + source + " to " + destination);
+    public void copyFile(Log log, File source, File destination) throws IOException, MojoExecutionException {
+        log.info("Copying " + source + " to " + destination);
 
-            if (source.isDirectory()) {
-                // usual case is a future jar packaging, but there are special cases: classifier and other packaging
-                throw new MojoExecutionException("Artifact has not been packaged yet. When used on reactor artifact, "
-                        + "copy should be executed after packaging: see MDEP-187.");
-            }
-
-            FileUtils.copyFile(source, destination);
-            buildContext.refresh(destination);
-        } catch (IOException e) {
-            throw new MojoExecutionException("Error copying artifact from " + source + " to " + destination, e);
+        if (source.isDirectory()) {
+            // usual case is a future jar packaging, but there are special cases: classifier and other packaging
+            throw new MojoExecutionException("Artifact has not been packaged yet. When used on reactor artifact, "
+                    + "copy should be executed after packaging: see MDEP-187.");
         }
+
+        FileUtils.copyFile(source, destination);
+        buildContext.refresh(destination);
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/CopyUtil.java
@@ -26,8 +26,9 @@ import java.io.File;
 import java.io.IOException;
 
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.logging.Log;
 import org.codehaus.plexus.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -36,6 +37,8 @@ import org.sonatype.plexus.build.incremental.BuildContext;
 @Named
 @Singleton
 public class CopyUtil {
+
+    private final Logger logger = LoggerFactory.getLogger(CopyUtil.class);
 
     private final BuildContext buildContext;
 
@@ -51,8 +54,8 @@ public class CopyUtil {
      * @param destination file name of destination file.
      * @throws IOException with a message if an error occurs.
      */
-    public void copyFile(Log log, File source, File destination) throws IOException, MojoExecutionException {
-        log.info("Copying " + source + " to " + destination);
+    public void copyFile(File source, File destination) throws IOException, MojoExecutionException {
+        logger.info("Copying {} to {}", source, destination);
 
         if (source.isDirectory()) {
             // usual case is a future jar packaging, but there are special cases: classifier and other packaging

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
@@ -26,12 +26,14 @@ import org.apache.maven.plugin.LegacySupport;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.plugins.dependency.testUtils.DependencyArtifactStubFactory;
+import org.apache.maven.plugins.dependency.utils.CopyUtil;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
+import org.sonatype.plexus.build.incremental.DefaultBuildContext;
 
 public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCase {
 
@@ -68,7 +70,7 @@ public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCas
     }
 
     protected void copyFile(AbstractDependencyMojo mojo, File artifact, File destFile) throws MojoExecutionException {
-        mojo.copyFile(artifact, destFile);
+        new CopyUtil(new DefaultBuildContext()).copyFile(mojo.getLog(), artifact, destFile);
     }
 
     protected void installLocalRepository(LegacySupport legacySupport) throws ComponentLookupException {

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
@@ -69,7 +69,8 @@ public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCas
         }
     }
 
-    protected void copyFile(AbstractDependencyMojo mojo, File artifact, File destFile) throws MojoExecutionException {
+    protected void copyFile(AbstractDependencyMojo mojo, File artifact, File destFile)
+            throws MojoExecutionException, IOException {
         new CopyUtil(new DefaultBuildContext()).copyFile(mojo.getLog(), artifact, destFile);
     }
 

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
@@ -69,9 +69,8 @@ public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCas
         }
     }
 
-    protected void copyFile(AbstractDependencyMojo mojo, File artifact, File destFile)
-            throws MojoExecutionException, IOException {
-        new CopyUtil(new DefaultBuildContext()).copyFile(mojo.getLog(), artifact, destFile);
+    protected void copyFile(File artifact, File destFile) throws MojoExecutionException, IOException {
+        new CopyUtil(new DefaultBuildContext()).copyFile(artifact, destFile);
     }
 
     protected void installLocalRepository(LegacySupport legacySupport) throws ComponentLookupException {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
@@ -87,7 +87,7 @@ public class TestCopyDependenciesMojo extends AbstractDependencyMojoTestCase {
 
         assertFalse(dest.exists());
 
-        copyFile(mojo, src, dest);
+        copyFile(src, dest);
         assertTrue(dest.exists());
     }
 

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
@@ -80,7 +80,7 @@ public class TestCopyDependenciesMojo extends AbstractDependencyMojoTestCase {
         assertFalse(handle.isMarkerSet());
     }
 
-    public void testCopyFile() throws MojoExecutionException, IOException {
+    public void testCopyFile() throws Exception {
         File src = File.createTempFile("copy", null);
 
         File dest = new File(mojo.outputDirectory, "toMe.jar");


### PR DESCRIPTION
this method is only needed in CopyMojo and CopyDependenciesMojo so it is not needed in AbstractDependencyMojo
