### PR TITLE
Fix mismatching Parameter initial field values

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/AbstractFromDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/AbstractFromDependenciesMojo.java
@@ -104,7 +104,7 @@ public abstract class AbstractFromDependenciesMojo extends AbstractDependencyFil
      * @since 2.0-alpha-2
      */
     @Parameter(property = "mdep.failOnMissingClassifierArtifact", defaultValue = "false")
-    protected boolean failOnMissingClassifierArtifact = true;
+    protected boolean failOnMissingClassifierArtifact;
 
     /**
      * @return Returns the outputDirectory.

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
@@ -64,7 +64,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
      * @since 2.0
      */
     @Parameter(property = "mdep.copyPom", defaultValue = "false")
-    protected boolean copyPom = true;
+    protected boolean copyPom;
 
     @Component
     private CopyUtil copyUtil;

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
@@ -429,6 +429,7 @@ public class TestCopyDependenciesMojo extends AbstractDependencyMojoTestCase {
 
     public void dotestArtifactExceptions() throws MojoFailureException {
         mojo.classifier = "jdk";
+        mojo.failOnMissingClassifierArtifact = true;
         mojo.type = "java-sources";
 
         try {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
@@ -491,16 +491,13 @@ public class TestUnpackDependenciesMojo extends AbstractDependencyMojoTestCase {
         }
     }
 
-    public void testArtifactNotFound() throws Exception {
-        dotestArtifactExceptions(false, true);
+    public void testArtifactResolutionException() throws MojoFailureException {
+        dotestArtifactExceptions();
     }
 
-    public void testArtifactResolutionException() throws Exception {
-        dotestArtifactExceptions(true, false);
-    }
-
-    public void dotestArtifactExceptions(boolean are, boolean anfe) throws Exception {
+    public void dotestArtifactExceptions() throws MojoFailureException {
         mojo.classifier = "jdk";
+        mojo.failOnMissingClassifierArtifact = true;
         mojo.type = "java-sources";
 
         try {


### PR DESCRIPTION
If I understand it correctly, if a Mojo parameter has a `@Parameter#defaultValue`, that value overwrites the initial value of the field (if any).

This pull request therefore fixes two cases where the initial field value did not match the `@Parameter#defaultValue`, which could have lead to confusion.

- For `AbstractFromDependenciesMojo#failOnMissingClassifierArtifact` it seems this issue was accidentally introduced by https://github.com/apache/maven-dependency-plugin/commit/1592cdc1979b90c9f59765affd47ec49cca38ec7#diff-b352be9b15d48a15ddf79e115c28c4cc776b7ec2662f553e189a978261d34881R100; the Javadoc had previously `default-value="true"`, which was matching the field value `true`, and was accidentally changed to `false`.
Though I am not going to adjust the default value to be `true` again since it has been `false` now for multiple years apparently.

    The test classes `TestUnpackDependenciesMojo` and `TestCopyDependenciesMojo` had to be adjusted because they were apparently not creating the Mojo instances they way Maven would normally do and therefore were relying on the field values instead of the `defaultValue`. For example when using the following `pom.xml` and running `mvn package`, you will see that the Dependency Plugin does not report an error for a missing classifier by default:

    <details>
    
    <summary><code>pom.xml</code> (click to expand)</summary>
    
    ```xml
    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
      xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
      <modelVersion>4.0.0</modelVersion>
      
      <groupId>com.mycompany.app</groupId>
      <artifactId>my-app</artifactId>
      <version>1.0-SNAPSHOT</version>
      
      <dependencies>
        <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <version>4.12</version>
        </dependency>
      </dependencies>

      <build>
        <plugins>
          <plugin>
            <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-dependency-plugin</artifactId>
            <version>3.7.1</version>
            <executions>
              <execution>
                <id>copy-dependencies</id>
                <phase>package</phase>
                <goals>
                  <goal>copy-dependencies</goal>
                </goals>
                <configuration>
                  <classifier>does-not-exist</classifier>
                  <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
                </configuration>
              </execution>
            </executions>
          </plugin>
        </plugins>
      </build>
    </project>
    ```
    
    </details>


- For `CopyDependenciesMojo#copyPom` it looks like it always had this mismatch since it was added by 32a29e6d063c6a377dfb4453bb9458a168458c09

---

Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MDEP) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[MDEP-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MDEP-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

