### PR TITLE
[MDEP-957] By default, don't report slf4j-simple as unused

### DIFF
--- a/src/it/projects/analyze/pom.xml
+++ b/src/it/projects/analyze/pom.xml
@@ -52,6 +52,12 @@
       <artifactId>maven-model</artifactId>
       <version>2.0.6</version>
     </dependency>
+    <!-- MDEP-957 slf4j-simple is unused but should not be reported -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.16</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -228,11 +228,15 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
      * </p>
+     * <p>
+     * By default, org.slf4j:slf4j-simple is ignored. Setting this property to an empty list
+     * will allow it to be detected.
+     * </p>
      *
      * @since 2.10
      */
     @Parameter
-    private String[] ignoredUnusedDeclaredDependencies = new String[0];
+    private String[] ignoredUnusedDeclaredDependencies = {"org.slf4j:slf4j-simple::"};
 
     /**
      * List of dependencies that will be ignored if they are in not test scope but are only used in test classes.
@@ -248,11 +252,15 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
      * </p>
+     * <p>
+     * By default, org.slf4j:slf4j-simple is ignored. Setting this property to an empty list
+     * will allow it to be detected.
+     * </p>
      *
      * @since 3.3.0
      */
     @Parameter
-    private String[] ignoredNonTestScopedDependencies = new String[0];
+    private String[] ignoredNonTestScopedDependencies = {"org.slf4j:slf4j-simple::"};
 
     /**
      * List of project packaging that will be ignored.

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -216,7 +216,7 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
     private String[] ignoredUsedUndeclaredDependencies = new String[0];
 
     /**
-     * List of dependencies that will be ignored if they are declared but unused. The filter syntax is:
+     * List of dependencies that are ignored if they are declared but unused. The filter syntax is:
      *
      * <pre>
      * [groupId]:[artifactId]:[type]:[version]
@@ -225,12 +225,8 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      * where each pattern segment is optional and supports full and partial <code>*</code> wildcards. An empty pattern
      * segment is treated as an implicit wildcard. *
      * <p>
-     * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
+     * For example, <code>org.apache.*</code> matches all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
-     * </p>
-     * <p>
-     * By default, org.slf4j:slf4j-simple is ignored. Setting this property to an empty list
-     * will allow it to be detected.
      * </p>
      *
      * @since 2.10
@@ -239,7 +235,7 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
     private String[] ignoredUnusedDeclaredDependencies;
 
     /**
-     * List of dependencies that will be ignored if they are in not test scope but are only used in test classes.
+     * List of dependencies that are ignored if they are in not test scope but are only used in test classes.
      * The filter syntax is:
      *
      * <pre>
@@ -249,12 +245,8 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      * where each pattern segment is optional and supports full and partial <code>*</code> wildcards. An empty pattern
      * segment is treated as an implicit wildcard. *
      * <p>
-     * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
+     * For example, <code>org.apache.*</code> matched all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
-     * </p>
-     * <p>
-     * By default, org.slf4j:slf4j-simple is ignored. Setting this property to an empty list
-     * will allow it to be detected.
      * </p>
      *
      * @since 3.3.0

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -235,8 +235,8 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      *
      * @since 2.10
      */
-    @Parameter
-    private String[] ignoredUnusedDeclaredDependencies = {"org.slf4j:slf4j-simple::"};
+    @Parameter(defaultValue = "org.slf4j:slf4j-simple::")
+    private String[] ignoredUnusedDeclaredDependencies;
 
     /**
      * List of dependencies that will be ignored if they are in not test scope but are only used in test classes.
@@ -259,8 +259,8 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
      *
      * @since 3.3.0
      */
-    @Parameter
-    private String[] ignoredNonTestScopedDependencies = {"org.slf4j:slf4j-simple::"};
+    @Parameter(defaultValue = "org.slf4j:slf4j-simple::")
+    private String[] ignoredNonTestScopedDependencies;
 
     /**
      * List of project packaging that will be ignored.


### PR DESCRIPTION
slf4j-simple is a super common "unused" dependency because when slfj-api or slf4j-impl is included and slf4j-simple isn't, the application works just fine but prints an annoying log message to the console telling developers to add it.

```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
```

or 
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

so devs deliberately add slf4j-simple to their dependencies just to shut up these warnings.

see https://www.slf4j.org/manual.html