### PR TITLE
[MNG-5988] Drop `commons-io` from explicit test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,12 @@ under the License.
       <artifactId>maven-reporting-impl</artifactId>
       <version>4.0.0-M15</version>
     </dependency>
+    <!-- Required transitive dependency, even if only used in tests. -->
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.16.1</version>
+    </dependency>
 
     <!-- plexus -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,12 +161,6 @@ under the License.
       <artifactId>maven-reporting-impl</artifactId>
       <version>4.0.0-M15</version>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.16.1</version>
-      <scope>test</scope>
-    </dependency>
 
     <!-- plexus -->
     <dependency>


### PR DESCRIPTION
Hello,

First thanks for your great work 👍 

Currently, I get the following error when using the plugin (3.8.0):
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.8.0:unpack-dependencies (unpack) on project opportunity-service: Execution unpack of goal org.apache.maven.plugins:maven-dependency-plugin:3.8.0:unpack-dependencies failed: A required class was missing while executing org.apache.maven.plugins:maven-dependency-plugin:3.8.0:unpack-dependencies: org/apache/commons/io/build/AbstractStreamBuilder
```

I believe this is because `commons-io` is a transitive deps of `org.codehaus.plexus:plexus-archiver`.
So declaring as a test scope exclude it, and leads to such errors.  
Here is a diff of `mvn dependency:tree` result between master and this PR:
```
 [INFO] |  +- org.apache.maven.doxia:doxia-module-xdoc:jar:2.0.0-M12:runtime
 [INFO] |  \- org.apache.maven:maven-archiver:jar:3.6.2:compile
-[INFO] +- commons-io:commons-io:jar:2.16.1:test
 [INFO] +- org.codehaus.plexus:plexus-archiver:jar:4.10.0:compile
+[INFO] |  +- commons-io:commons-io:jar:2.16.1:compile
 [INFO] |  +- org.apache.commons:commons-compress:jar:1.26.2:compile
 [INFO] |  |  \- commons-codec:commons-codec:jar:1.17.0:compile
 [INFO] |  +- io.airlift:aircompressor:jar:0.27:compile
 ```  
 
I know for sure that the bug didn't exist in 3.2.0. 

I now need to resume to my job activities. 

I will post an update when tested (~tomorrow), and LMK if I need to open a Jira.
Edit: tested locally with the latest changes; it fixes my build. 