### PR TITLE
Fixing flaky tests in TestTreeMojo

### DIFF
--- a/src/test/java/org/apache/maven/plugins/dependency/tree/TestTreeMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/tree/TestTreeMojo.java
@@ -31,7 +31,11 @@ import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.maven.artifact.Artifact;


### PR DESCRIPTION
### Description

This pull request addresses the flakiness in the following tests within the class [org.apache.maven.plugins.dependency.tree.TestTreeMojo](https://github.com/apache/maven-dependency-plugin/blob/b19b7e027085fb215f8f510d7bef8033ecbd4d48/src/test/java/org/apache/maven/plugins/dependency/tree/TestTreeMojo.java#L54):

1. [TestTreeMojo#testTreeTestEnvironment](https://github.com/apache/maven-dependency-plugin/blob/b19b7e027085fb215f8f510d7bef8033ecbd4d48/src/test/java/org/apache/maven/plugins/dependency/tree/TestTreeMojo.java#L83)
2. [TestTreeMojo#testTreeJsonParsing](https://github.com/apache/maven-dependency-plugin/blob/b19b7e027085fb215f8f510d7bef8033ecbd4d48/src/test/java/org/apache/maven/plugins/dependency/tree/TestTreeMojo.java#L180)

These tests exhibit flakiness due to non-deterministic ordering of child dependency artifacts within a `DependencyNode`. The first test checks the children of a `DependencyNode`, while the second test performs similar checks on a `JsonArray`. Since the order of dependencies is non-deterministic, these tests occasionally fail when executed in different environments or under specific conditions.

This flakiness can be reproduced by executing this command on the class using the [Nondex](https://github.com/TestingResearchIllinois/NonDex) plugin.

`mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.apache.maven.plugins.dependency.tree.TestTreeMojo" `

These two tests occasionally fail with these errors - 

```
[ERROR] Failures:
[ERROR]   TestTreeMojo.testTreeJsonParsing:200 expected:<[snapshot]> but was:<[release]>
[ERROR]   TestTreeMojo.testTreeTestEnvironment:104->assertChildNodeEquals:277->assertNodeEquals:283->assertNodeEquals:296 artifact id expected:<[release]> but was:<[snapshot]>
[INFO]
[ERROR] Tests run: 6, Failures: 2, Errors: 0, Skipped: 0

```


### Solution

This PR resolves these issues by:
1. **Making Artifact Comparisons Order-Agnostic**: In the `testTreeTestEnvironment` method, this PR generates artifact coordinate strings for the expected nodes and compares them against actual nodes without relying on a specific order.
2. **Sorting JSON Array by Artifact ID**: In `testTreeJsonParsing`, the PR sorts the `JsonArray` by `artifactId` before performing assertions. This ensures that the checks are stable and unaffected by non-deterministic ordering.

This approach ensures the tests pass reliably regardless of artifact order, eliminating flakiness due to ordering variations.

### Testing and Verification

I verified the stability of these changes by re-running the tests multiple times with NonDex. The updated tests no longer exhibit flakiness, consistently passing as expected.

I'd appreciate any feedback on this PR. Please let me know if there are additional changes or considerations you'd like me to address!

---

- [x] I hereby declare this contribution to be licensed under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)


