### PR TITLE
Use linefeed directly to avoid platform dependent code

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
@@ -99,7 +99,7 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
             }));
 
             if (repositories.isEmpty()) {
-                getLog().info("No remote repository is used by this build." + System.lineSeparator());
+                getLog().info("No remote repository is used by this build.\n");
                 return;
             }
 
@@ -132,16 +132,16 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
                 .append(repo)
                 .append(" mirrored by ")
                 .append(mirror)
-                .append(System.lineSeparator()));
+                .append("\n"));
     }
 
     private void prepareRemoteRepositoriesList(
             StringBuilder message, Collection<RemoteRepository> remoteProjectRepositories) {
 
-        message.append("Project remote repositories used by this build:").append(System.lineSeparator());
+        message.append("Project remote repositories used by this build:\n");
 
         remoteProjectRepositories.forEach(
-                repo -> message.append(" * ").append(repo).append(System.lineSeparator()));
+                repo -> message.append(" * ").append(repo).append("\n"));
     }
 
     private Map<RemoteRepository, RemoteRepository> getMirroredRepo(Set<RemoteRepository> repositories) {

--- a/src/main/java/org/apache/maven/plugins/dependency/PurgeLocalRepositoryMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/PurgeLocalRepositoryMojo.java
@@ -623,13 +623,11 @@ public class PurgeLocalRepositoryMojo extends AbstractMojo {
         }
 
         if (!missingArtifacts.isEmpty()) {
-            StringBuilder message = new StringBuilder("required artifacts missing:");
-            message.append(System.lineSeparator());
+            StringBuilder message = new StringBuilder("required artifacts missing:\n");
             for (Artifact missingArtifact : missingArtifacts) {
-                message.append("  ").append(missingArtifact.getId()).append(System.lineSeparator());
+                message.append("  ").append(missingArtifact.getId()).append("\n");
             }
-            message.append(System.lineSeparator());
-            message.append("for the artifact:");
+            message.append("\nfor the artifact:");
 
             throw new ArtifactResolutionException(
                     message.toString(), theProject.getArtifact(), theProject.getRemoteArtifactRepositories());

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -527,7 +527,7 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                 writer.endElement();
             }
 
-            getLog().info(System.lineSeparator() + out.getBuffer());
+            getLog().info("\n" + out.getBuffer());
         }
     }
 
@@ -552,9 +552,9 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                         .append(artifact.getBaseVersion())
                         .append(":")
                         .append(artifact.getScope())
-                        .append(System.lineSeparator());
+                        .append("\n");
             }
-            getLog().info(System.lineSeparator() + buf);
+            getLog().info("\n" + buf);
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
@@ -228,7 +228,7 @@ public class BuildClasspathMojo extends AbstractDependencyFilterMojo implements 
         }
 
         if (outputFile == null) {
-            getLog().info("Dependencies classpath:" + System.lineSeparator() + cpString);
+            getLog().info("Dependencies classpath:\n" + cpString);
         } else {
             if (regenerateFile || !isUpToDate(cpString)) {
                 storeClasspathFile(cpString, outputFile);

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
@@ -142,13 +142,10 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
      */
     public String getOutput(boolean outputAbsoluteArtifactFilename, boolean theOutputScope, boolean theSort) {
         StringBuilder sb = new StringBuilder();
-        sb.append(System.lineSeparator());
-        sb.append("The following files have been resolved:");
-        sb.append(System.lineSeparator());
+        sb.append("\nThe following files have been resolved:\n");
         if (results.getResolvedDependencies() == null
                 || results.getResolvedDependencies().isEmpty()) {
-            sb.append("   none");
-            sb.append(System.lineSeparator());
+            sb.append("   none\n");
         } else {
             sb.append(buildArtifactListOutput(
                     results.getResolvedDependencies(), outputAbsoluteArtifactFilename, theOutputScope, theSort));
@@ -156,9 +153,7 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
 
         if (results.getSkippedDependencies() != null
                 && !results.getSkippedDependencies().isEmpty()) {
-            sb.append(System.lineSeparator());
-            sb.append("The following files were skipped:");
-            sb.append(System.lineSeparator());
+            sb.append("\nThe following files were skipped:\n");
             Set<Artifact> skippedDependencies = new LinkedHashSet<>(results.getSkippedDependencies());
             sb.append(buildArtifactListOutput(
                     skippedDependencies, outputAbsoluteArtifactFilename, theOutputScope, theSort));
@@ -166,14 +161,12 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
 
         if (results.getUnResolvedDependencies() != null
                 && !results.getUnResolvedDependencies().isEmpty()) {
-            sb.append(System.lineSeparator());
-            sb.append("The following files have NOT been resolved:");
-            sb.append(System.lineSeparator());
+            sb.append("\nThe following files have NOT been resolved:\n");
             Set<Artifact> unResolvedDependencies = new LinkedHashSet<>(results.getUnResolvedDependencies());
             sb.append(buildArtifactListOutput(
                     unResolvedDependencies, outputAbsoluteArtifactFilename, theOutputScope, theSort));
         }
-        sb.append(System.lineSeparator());
+        sb.append("\n");
 
         return sb.toString();
     }
@@ -224,7 +217,7 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
                     }
                 }
             }
-            artifactStringList.add(messageBuilder + System.lineSeparator());
+            artifactStringList.add(messageBuilder + "\n");
         }
         if (theSort) {
             Collections.sort(artifactStringList);

--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolvePluginsMojo.java
@@ -79,12 +79,9 @@ public class ResolvePluginsMojo extends AbstractResolveMojo {
             final Set<Artifact> plugins = resolvePluginArtifacts();
 
             StringBuilder sb = new StringBuilder();
-            sb.append(System.lineSeparator());
-            sb.append("The following plugins have been resolved:");
-            sb.append(System.lineSeparator());
+            sb.append("\nThe following plugins have been resolved:\n");
             if (plugins == null || plugins.isEmpty()) {
-                sb.append("   none");
-                sb.append(System.lineSeparator());
+                sb.append("   none\n");
             } else {
                 for (Artifact plugin : plugins) {
                     String artifactFilename = null;
@@ -103,7 +100,7 @@ public class ResolvePluginsMojo extends AbstractResolveMojo {
                     sb.append("   ")
                             .append(id)
                             .append(outputAbsoluteArtifactFilename ? ":" + artifactFilename : "")
-                            .append(System.lineSeparator());
+                            .append("\n");
 
                     if (!excludeTransitive) {
                         DefaultDependableCoordinate pluginCoordinate = new DefaultDependableCoordinate();
@@ -128,11 +125,11 @@ public class ResolvePluginsMojo extends AbstractResolveMojo {
                             sb.append("      ")
                                     .append(id)
                                     .append(outputAbsoluteArtifactFilename ? ":" + artifactFilename : "")
-                                    .append(System.lineSeparator());
+                                    .append("\n");
                         }
                     }
                 }
-                sb.append(System.lineSeparator());
+                sb.append("\n");
 
                 String output = sb.toString();
                 if (outputFile == null) {

--- a/src/main/java/org/apache/maven/plugins/dependency/tree/DOTDependencyNodeVisitor.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/tree/DOTDependencyNodeVisitor.java
@@ -48,7 +48,7 @@ public class DOTDependencyNodeVisitor extends AbstractSerializingVisitor impleme
     @Override
     public boolean visit(DependencyNode node) {
         if (node.getParent() == null || node.getParent() == node) {
-            writer.write("digraph \"" + node.toNodeString() + "\" { " + System.lineSeparator());
+            writer.write("digraph \"" + node.toNodeString() + "\" { \n");
         }
 
         // Generate "currentNode -> Child" lines

--- a/src/main/java/org/apache/maven/plugins/dependency/tree/GraphmlDependencyNodeVisitor.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/tree/GraphmlDependencyNodeVisitor.java
@@ -40,10 +40,10 @@ public class GraphmlDependencyNodeVisitor extends AbstractSerializingVisitor imp
             + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
             + "xmlns:y=\"http://www.yworks.com/xml/graphml\" "
             + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + System.lineSeparator()
-            + "  <key for=\"node\" id=\"d0\" yfiles.type=\"nodegraphics\"/> " + System.lineSeparator()
-            + "  <key for=\"edge\" id=\"d1\" yfiles.type=\"edgegraphics\"/> " + System.lineSeparator()
-            + "<graph id=\"dependencies\" edgedefault=\"directed\">" + System.lineSeparator();
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">\n"
+            + "  <key for=\"node\" id=\"d0\" yfiles.type=\"nodegraphics\"/> \n"
+            + "  <key for=\"edge\" id=\"d1\" yfiles.type=\"edgegraphics\"/> \n"
+            + "<graph id=\"dependencies\" edgedefault=\"directed\">\n";
 
     /**
      * Graphml xml file footer.

--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
@@ -67,7 +67,7 @@ public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCas
                 FileUtils.deleteDirectory(testDir);
             } catch (IOException e) {
                 e.printStackTrace();
-                fail("Trying to remove directory: " + testDir + System.lineSeparator() + e);
+                fail("Trying to remove directory: " + testDir + "\n" + e);
             }
             assertFalse(testDir.exists());
         }

--- a/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDuplicateMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/analyze/TestAnalyzeDuplicateMojo.java
@@ -122,7 +122,7 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
 
         /** {@inheritDoc} */
         public void error(CharSequence content) {
-            System.err.println("[error] " + content.toString());
+            System.err.println("[error] " + content);
         }
 
         /** {@inheritDoc} */
@@ -132,8 +132,7 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
 
             error.printStackTrace(pWriter);
 
-            System.err.println(
-                    "[error] " + content.toString() + System.lineSeparator() + System.lineSeparator() + sWriter);
+            System.err.println("[error] " + content + "\n\n" + sWriter);
         }
 
         /**
@@ -182,7 +181,7 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
                     .append(prefix)
                     .append("] ")
                     .append(content.toString())
-                    .append(System.lineSeparator());
+                    .append("\n");
         }
 
         private void print(String prefix, Throwable error) {
@@ -191,7 +190,7 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
 
             error.printStackTrace(pWriter);
 
-            sb.append("[").append(prefix).append("] ").append(sWriter).append(System.lineSeparator());
+            sb.append("[").append(prefix).append("] ").append(sWriter).append("\n");
         }
 
         private void print(String prefix, CharSequence content, Throwable error) {
@@ -204,9 +203,8 @@ public class TestAnalyzeDuplicateMojo extends AbstractDependencyMojoTestCase {
                     .append(prefix)
                     .append("] ")
                     .append(content.toString())
-                    .append(System.lineSeparator())
-                    .append(System.lineSeparator());
-            sb.append(sWriter).append(System.lineSeparator());
+                    .append("\n\n");
+            sb.append(sWriter).append("\n");
         }
 
         protected String getContent() {

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -306,8 +306,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
 
             error.printStackTrace(pWriter);
 
-            System.err.println(
-                    "[error] " + content.toString() + System.lineSeparator() + System.lineSeparator() + sWriter);
+            System.err.println("[error] " + content + "\n\n" + sWriter);
         }
 
         /**
@@ -356,7 +355,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
                     .append(prefix)
                     .append("] ")
                     .append(content.toString())
-                    .append(System.lineSeparator());
+                    .append("\n");
         }
 
         private void print(String prefix, Throwable error) {
@@ -365,7 +364,7 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
 
             error.printStackTrace(pWriter);
 
-            sb.append("[").append(prefix).append("] ").append(sWriter).append(System.lineSeparator());
+            sb.append("[").append(prefix).append("] ").append(sWriter).append("\n\n");
         }
 
         private void print(String prefix, CharSequence content, Throwable error) {
@@ -374,13 +373,8 @@ public class AnalyzeExclusionsMojoTest extends AbstractDependencyMojoTestCase {
 
             error.printStackTrace(pWriter);
 
-            sb.append("[")
-                    .append(prefix)
-                    .append("] ")
-                    .append(content.toString())
-                    .append(System.lineSeparator())
-                    .append(System.lineSeparator());
-            sb.append(sWriter).append(System.lineSeparator());
+            sb.append("[").append(prefix).append("] ").append(content).append("\n\n");
+            sb.append(sWriter).append("\n");
         }
 
         protected String getContent() {

--- a/src/test/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojoTest.java
@@ -57,7 +57,7 @@ public class ResolveDependenciesMojoTest extends AbstractDependencyMojoTestCase 
         ResolveDependenciesMojo mojo = newMojo(new DependencyStatusSets());
         mojo.results.setResolvedDependencies(set);
         String output = mojo.getOutput(false, true, false);
-        assertTrue(output.contains("g:a:jar:1.0:test (optional)" + System.lineSeparator()));
+        assertTrue(output.contains("g:a:jar:1.0:test (optional)\n"));
     }
 
     public void doTestDependencyStatusLog(Set<Artifact> artifacts) {

--- a/src/test/java/org/apache/maven/plugins/dependency/utils/TestDependencyUtil.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/utils/TestDependencyUtil.java
@@ -39,8 +39,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class TestDependencyUtil {
 
-    private static final String TEST_CONTENT =
-            "Test line 1" + System.lineSeparator() + "Test line 2" + System.lineSeparator();
+    private static final String TEST_CONTENT = "Test line 1\n" + "Test line 2\n";
 
     @TempDir
     File temDir;


### PR DESCRIPTION
This plugin seems to have a lot of usage of System.lineSeparator that produces platform dependent output and logs. These days I think pretty much every terminal on every platform should work with a simple \n and when the log goes anywhere other than a terminal then \n works better.