### PR TITLE
[MDEP-952] Partially decouple AbstractFromConfigurationMojo from StringUtils

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -181,10 +181,6 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             } catch (ArtifactFilterException e) {
                 throw new MojoExecutionException(e.getMessage(), e);
             }
-
-            if (artifactItem.getType() == null) {
-                throw new NullPointerException("Missing type for " + artifactItem.getArtifactId());
-            }
         }
         return artifactItems;
     }
@@ -220,10 +216,6 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             coordinate.setVersion(artifactItem.getVersion());
             coordinate.setClassifier(artifactItem.getClassifier());
 
-            String type = artifactItem.getType();
-            if (type == null) {
-                throw new NullPointerException("missing type");
-            }
             final String extension;
 
             ArtifactHandler artifactHandler = artifactHandlerManager.getArtifactHandler(artifactItem.getType());

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -163,7 +163,7 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             artifactItem.getOutputDirectory().mkdirs();
 
             // make sure we have a version.
-            if (artifactItem.getVersion() != null && !artifactItem.getVersion().isEmpty()) {
+            if (artifactItem.getVersion() == null || artifactItem.getVersion().isEmpty()) {
                 fillMissingArtifactVersion(artifactItem);
             }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
@@ -180,6 +181,10 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             } catch (ArtifactFilterException e) {
                 throw new MojoExecutionException(e.getMessage(), e);
             }
+
+            if (artifactItem.getType() == null) {
+                throw new NullPointerException("Missing type for " + artifactItem.getArtifactId());
+            }
         }
         return artifactItems;
     }
@@ -215,7 +220,12 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             coordinate.setVersion(artifactItem.getVersion());
             coordinate.setClassifier(artifactItem.getClassifier());
 
+            String type = artifactItem.getType();
+            if (type == null) {
+                throw new NullPointerException("missing type");
+            }
             final String extension;
+
             ArtifactHandler artifactHandler = artifactHandlerManager.getArtifactHandler(artifactItem.getType());
             if (artifactHandler != null) {
                 extension = artifactHandler.getExtension();
@@ -367,7 +377,7 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
         if (artifact != null) {
             String packaging = "jar";
             String classifier;
-            String[] tokens = artifact.split(":");
+            String[] tokens = StringUtils.split(artifact, ":");
             if (tokens.length < 3 || tokens.length > 5) {
                 throw new MojoFailureException("Invalid artifact, "
                         + "you must specify groupId:artifactId:version[:packaging[:classifier]] " + artifact);

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -169,7 +169,8 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
 
             artifactItem.setArtifact(this.getArtifact(artifactItem));
 
-            if (artifactItem.getDestFileName() == null || artifactItem.getDestFileName().length() == 0) {
+            if (artifactItem.getDestFileName() == null
+                    || artifactItem.getDestFileName().length() == 0) {
                 artifactItem.setDestFileName(DependencyUtil.getFormattedFileName(
                         artifactItem.getArtifact(), removeVersion, prependGroupId, useBaseVersion, removeClassifier));
             }

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
@@ -164,13 +163,13 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             artifactItem.getOutputDirectory().mkdirs();
 
             // make sure we have a version.
-            if (StringUtils.isEmpty(artifactItem.getVersion())) {
+            if (artifactItem.getVersion() != null && !artifactItem.getVersion().isEmpty()) {
                 fillMissingArtifactVersion(artifactItem);
             }
 
             artifactItem.setArtifact(this.getArtifact(artifactItem));
 
-            if (StringUtils.isEmpty(artifactItem.getDestFileName())) {
+            if (artifactItem.getDestFileName() == null || artifactItem.getDestFileName().length() == 0) {
                 artifactItem.setDestFileName(DependencyUtil.getFormattedFileName(
                         artifactItem.getArtifact(), removeVersion, prependGroupId, useBaseVersion, removeClassifier));
             }
@@ -185,7 +184,7 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
     }
 
     private boolean checkIfProcessingNeeded(ArtifactItem item) throws MojoExecutionException, ArtifactFilterException {
-        return StringUtils.equalsIgnoreCase(item.getOverWrite(), "true")
+        return "true".equalsIgnoreCase(item.getOverWrite())
                 || getMarkedArtifactFilter(item).isArtifactIncluded(item);
     }
 
@@ -367,7 +366,7 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
         if (artifact != null) {
             String packaging = "jar";
             String classifier;
-            String[] tokens = StringUtils.split(artifact, ":");
+            String[] tokens = artifact.split(":");
             if (tokens.length < 3 || tokens.length > 5) {
                 throw new MojoFailureException("Invalid artifact, "
                         + "you must specify groupId:artifactId:version[:packaging[:classifier]] " + artifact);

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
 import java.io.File;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -156,18 +157,18 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
     }
 
     /**
-     * @param removeVersion removeVersion
+     * @param removeVersion removeVersion.
      * @return list of {@link ArtifactItem}
-     * @throws MojoExecutionException in case of an error
+     * @throws MojoExecutionException in case of an error.
      */
     protected List<ArtifactItem> getProcessedArtifactItems(boolean removeVersion) throws MojoExecutionException {
         List<ArtifactItem> items =
                 super.getProcessedArtifactItems(new ProcessArtifactItemsRequest(removeVersion, false, false, false));
         for (ArtifactItem artifactItem : items) {
-            if (artifactItem.getIncludes().isEmpty()) {
+            if (StringUtils.isEmpty(artifactItem.getIncludes())) {
                 artifactItem.setIncludes(getIncludes());
             }
-            if (artifactItem.getExcludes().isEmpty()) {
+            if (StringUtils.isEmpty(artifactItem.getExcludes())) {
                 artifactItem.setExcludes(getExcludes());
             }
         }
@@ -175,7 +176,7 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
     }
 
     /**
-     * @return returns the markersDirectory
+     * @return Returns the markersDirectory.
      */
     public File getMarkersDirectory() {
         return this.markersDirectory;

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
 import java.io.File;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -157,18 +156,18 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
     }
 
     /**
-     * @param removeVersion removeVersion.
+     * @param removeVersion removeVersion
      * @return list of {@link ArtifactItem}
-     * @throws MojoExecutionException in case of an error.
+     * @throws MojoExecutionException in case of an error
      */
     protected List<ArtifactItem> getProcessedArtifactItems(boolean removeVersion) throws MojoExecutionException {
         List<ArtifactItem> items =
                 super.getProcessedArtifactItems(new ProcessArtifactItemsRequest(removeVersion, false, false, false));
         for (ArtifactItem artifactItem : items) {
-            if (StringUtils.isEmpty(artifactItem.getIncludes())) {
+            if (artifactItem.getIncludes().isEmpty()) {
                 artifactItem.setIncludes(getIncludes());
             }
-            if (StringUtils.isEmpty(artifactItem.getExcludes())) {
+            if (artifactItem.getExcludes().isEmpty()) {
                 artifactItem.setExcludes(getExcludes());
             }
         }
@@ -176,7 +175,7 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
     }
 
     /**
-     * @return Returns the markersDirectory.
+     * @return returns the markersDirectory
      */
     public File getMarkersDirectory() {
         return this.markersDirectory;


### PR DESCRIPTION
Needs a closer look. This appears to be the change that caused the bug MDEP-952

```
Running post-build script: /Users/elharo/maven-dependency-plugin/target/it/mdep-952-unpack-fails-if-extension-of-artifact-is-used/verify.groovy
Assertion failed: 

assert buildLog.contains( 'BUILD SUCCESS' )
       |        |
       |        false
```