### PR TITLE
[MDEP-952] Remove StringUtils from UnpackMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
 import java.io.File;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -165,10 +164,10 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
         List<ArtifactItem> items =
                 super.getProcessedArtifactItems(new ProcessArtifactItemsRequest(removeVersion, false, false, false));
         for (ArtifactItem artifactItem : items) {
-            if (StringUtils.isEmpty(artifactItem.getIncludes())) {
+            if (artifactItem.getIncludes().isEmpty()) {
                 artifactItem.setIncludes(getIncludes());
             }
-            if (StringUtils.isEmpty(artifactItem.getExcludes())) {
+            if (artifactItem.getExcludes().isEmpty()) {
                 artifactItem.setExcludes(getExcludes());
             }
         }


### PR DESCRIPTION
Includes and excludes can't be null so this method was never needed.