### PR TITLE
Clean up test teardown and temp directories

### DIFF
--- a/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/AbstractDependencyMojoTestCase.java
@@ -43,31 +43,27 @@ public abstract class AbstractDependencyMojoTestCase extends AbstractMojoTestCas
 
     protected DependencyArtifactStubFactory stubFactory;
 
-    protected void setUp(String testDirStr, boolean createFiles) throws Exception {
-        setUp(testDirStr, createFiles, true);
+    protected void setUp(String testDirectoryName, boolean createFiles) throws Exception {
+        setUp(testDirectoryName, createFiles, true);
     }
 
-    protected void setUp(String testDirStr, boolean createFiles, boolean flattenedPath) throws Exception {
+    protected void setUp(String testDirectoryName, boolean createFiles, boolean flattenedPath) throws Exception {
         // required for mojo lookups to work
         super.setUp();
 
-        testDir = Files.createTempDirectory("testDirStr").toFile();
+        testDir = Files.createTempDirectory(testDirectoryName).toFile();
         testDir.deleteOnExit();
 
         stubFactory = new DependencyArtifactStubFactory(this.testDir, createFiles, flattenedPath);
     }
 
     @Override
-    protected void tearDown() {
+    protected void tearDown() throws Exception {
         if (testDir != null) {
-            try {
-                FileUtils.deleteDirectory(testDir);
-            } catch (IOException e) {
-                e.printStackTrace();
-                fail("Trying to remove directory: " + testDir + System.lineSeparator() + e);
-            }
+            FileUtils.deleteDirectory(testDir);
             assertFalse(testDir.exists());
         }
+        super.tearDown();
     }
 
     protected void copyArtifactFile(Artifact sourceArtifact, File destFile) throws MojoExecutionException, IOException {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestIncludeExcludeUnpackMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestIncludeExcludeUnpackMojo.java
@@ -57,7 +57,7 @@ public class TestIncludeExcludeUnpackMojo extends AbstractDependencyMojoTestCase
         mojo = (UnpackMojo) lookupMojo("unpack", testPom);
         mojo.setOutputDirectory(new File(this.testDir, "outputDirectory"));
 
-        // i'm using one file repeatedly to archive so I can test the name
+        // I'm using one file repeatedly to archive so I can test the name
         // programmatically.
         stubFactory.setSrcFile(new File(getBasedir() + File.separatorChar + PACKED_FILE_PATH));
         Artifact artifact = stubFactory.createArtifact("test", "test", "1.0", Artifact.SCOPE_COMPILE, "jar", null);
@@ -75,11 +75,10 @@ public class TestIncludeExcludeUnpackMojo extends AbstractDependencyMojoTestCase
         installLocalRepository(legacySupport);
     }
 
-    protected void tearDown() {
-        super.tearDown();
-
+    protected void tearDown() throws Exception {
         mojo = null;
         System.gc();
+        super.tearDown();
     }
 
     public void assertMarkerFiles(Collection<ArtifactItem> items, boolean exist) {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestIncludeExcludeUnpackMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestIncludeExcludeUnpackMojo.java
@@ -75,12 +75,6 @@ public class TestIncludeExcludeUnpackMojo extends AbstractDependencyMojoTestCase
         installLocalRepository(legacySupport);
     }
 
-    protected void tearDown() throws Exception {
-        mojo = null;
-        System.gc();
-        super.tearDown();
-    }
-
     public void assertMarkerFiles(Collection<ArtifactItem> items, boolean exist) {
         for (ArtifactItem item : items) {
             assertMarkerFile(exist, item);

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestIncludeExcludeUnpackDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestIncludeExcludeUnpackDependenciesMojo.java
@@ -54,7 +54,7 @@ public class TestIncludeExcludeUnpackDependenciesMojo extends AbstractDependency
 
         // it needs to get the archivermanager
         // stubFactory.setUnpackableFile( mojo.getArchiverManager() );
-        // i'm using one file repeatedly to archive so I can test the name
+        // I'm using one file repeatedly to archive so I can test the name
         // programmatically.
         stubFactory.setSrcFile(new File(getBasedir() + File.separatorChar + PACKED_FILE_PATH));
 
@@ -68,13 +68,6 @@ public class TestIncludeExcludeUnpackDependenciesMojo extends AbstractDependency
         project.setArtifacts(artifacts);
         project.setDependencyArtifacts(directArtifacts);
         mojo.markersDirectory = new File(this.testDir, "markers");
-    }
-
-    protected void tearDown() {
-        super.tearDown();
-
-        mojo = null;
-        System.gc();
     }
 
     private void assertUnpacked(boolean unpacked, String fileName) {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
@@ -91,12 +91,6 @@ public class TestUnpackDependenciesMojo extends AbstractDependencyMojoTestCase {
         setVariableValueToObject(mojo, "artifactHandlerManager", manager);
     }
 
-    protected void tearDown() throws Exception {
-        mojo = null;
-        System.gc();
-        super.tearDown();
-    }
-
     public void assertUnpacked(Artifact artifact) {
         assertUnpacked(true, artifact);
     }

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo.java
@@ -91,11 +91,10 @@ public class TestUnpackDependenciesMojo extends AbstractDependencyMojoTestCase {
         setVariableValueToObject(mojo, "artifactHandlerManager", manager);
     }
 
-    protected void tearDown() {
-        super.tearDown();
-
+    protected void tearDown() throws Exception {
         mojo = null;
         System.gc();
+        super.tearDown();
     }
 
     public void assertUnpacked(Artifact artifact) {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo2.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo2.java
@@ -198,7 +198,7 @@ public class TestUnpackDependenciesMojo2 extends AbstractDependencyMojoTestCase 
 
         assertEquals(time, unpackedFile.lastModified());
         mojo.execute();
-        System.gc();
+
         // make sure it didn't overwrite
         assertEquals(time, unpackedFile.lastModified());
 
@@ -226,7 +226,7 @@ public class TestUnpackDependenciesMojo2 extends AbstractDependencyMojoTestCase 
         mojo.execute();
 
         if (overWrite) {
-            assertTrue(time != unpackedFile.lastModified());
+            assertNotEquals(time, unpackedFile.lastModified());
         } else {
             assertEquals(time, unpackedFile.lastModified());
         }

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo2.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestUnpackDependenciesMojo2.java
@@ -34,6 +34,8 @@ import org.apache.maven.plugins.dependency.utils.DependencyUtil;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.manager.ArchiverManager;
 
+import static org.junit.Assert.assertNotEquals;
+
 public class TestUnpackDependenciesMojo2 extends AbstractDependencyMojoTestCase {
 
     private final String UNPACKABLE_FILE = "test.txt";
@@ -71,13 +73,6 @@ public class TestUnpackDependenciesMojo2 extends AbstractDependencyMojoTestCase 
 
         project.setArtifacts(artifacts);
         mojo.markersDirectory = new File(this.testDir, "markers");
-    }
-
-    protected void tearDown() {
-        super.tearDown();
-
-        mojo = null;
-        System.gc();
     }
 
     public File getUnpackedFile(Artifact artifact) {
@@ -211,9 +206,7 @@ public class TestUnpackDependenciesMojo2 extends AbstractDependencyMojoTestCase 
 
         mojo.execute();
 
-        assertTrue(time != unpackedFile.lastModified());
-
-        System.gc();
+        assertNotEquals(time, unpackedFile.lastModified());
     }
 
     public void assertUnpacked(Artifact artifact, boolean overWrite)


### PR DESCRIPTION
1. temp directories were always named "testDirStr" rather than the value of testDirStr
2. Avoid unneeded garbage collection