### PR TITLE
Fix broken link for analyze-exclusions-mojo on usage-page

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -40,7 +40,7 @@ ${project.name}
   *{{{./analyze-dep-mgt-mojo.html}dependency:analyze-dep-mgt}} analyzes the project's dependencies and lists mismatches
   between resolved dependencies and those listed in your dependencyManagement section.
 
-  *{{{./analyze-exclusions.html}dependency:analyze-exclusions}} analyzes the exclusions on dependencies and checks if the artifact actually brings in the given dependency.
+  *{{{./analyze-exclusions-mojo.html}dependency:analyze-exclusions}} analyzes the exclusions on dependencies and checks if the artifact actually brings in the given dependency.
 
   *{{{./analyze-only-mojo.html}dependency:analyze-only}} is the same as analyze, but is meant to be bound in a pom. It
   does not fork the build and execute test-compile.
@@ -105,8 +105,6 @@ ${project.name}
 
   *{{{./unpack-dependencies-mojo.html}dependency:unpack-dependencies}} like
   copy-dependencies but unpacks.
-
-  *{{{./analyze-exclusions-mojo.html}dependency:analyze-exclusions}} displays invalid exclusions for this project.
 
   []
 


### PR DESCRIPTION
There were actual two links for the same goal, one with the correct link, but at the bottom of the page.
The broken one was added later in "alphabetical correct" position.

I fixed the one at the top where it belongs and removed the one at the bottom with 
