### PR TITLE
Update maven-dependency-analyzer to support Java24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@ under the License.
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-analyzer</artifactId>
-      <version>1.15.1</version>
+      <version>1.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/pom.xml
+++ b/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/pom.xml
@@ -33,9 +33,9 @@
 
   <dependencies>
     <dependency>
-      <groupId>net.java.dev.msv</groupId>
-      <artifactId>xsdlib</artifactId>
-      <version>2022.7</version>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-shared-utils</artifactId>
+      <version>3.4.2</version>
     </dependency>
   </dependencies>
   <build>

--- a/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/src/main/java/usedUndeclaredReference/Project.java
+++ b/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/src/main/java/usedUndeclaredReference/Project.java
@@ -21,5 +21,5 @@ package usedUndeclaredReference;
 
 public class Project
 {
-    public static final Class CLASS_REF = org.apache.xmlcommons.Version.class;
+    public static final Class CLASS_REF = org.apache.commons.io.IOUtils.class;
 }

--- a/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/verify.bsh
+++ b/src/it/projects/mdep-779-analyze-only-verbose-shows-class-names/verify.bsh
@@ -24,10 +24,10 @@ String log = FileUtils.fileRead( new File( basedir, "build.log" ) );
 log = StringUtils.unifyLineSeparators(log, "\n");
 
 String expected = "[WARNING] Used undeclared dependencies found:\n" +
-                  "[WARNING]    xml-apis:xml-apis:jar:1.4.01:compile\n" +
-                  "[WARNING]       class org.apache.xmlcommons.Version\n" +
+                  "[WARNING]    commons-io:commons-io:jar:2.11.0:compile\n" +
+                  "[WARNING]       class org.apache.commons.io.IOUtils\n" +
                   "[WARNING] Unused declared dependencies found:\n" +
-                  "[WARNING]    net.java.dev.msv:xsdlib:jar:2022.7:compile";
+                  "[WARNING]    org.apache.maven.shared:maven-shared-utils:jar:3.4.2:compile";
 
 if ( !log.contains(expected) )
 {


### PR DESCRIPTION
This commit updates the analyser version which supports reading byte code generated by Java 24.

Fixes #524

Following this checklist to help us incorporate your
contribution quickly and easily:

- [X] Your pull request should address just one issue, without pulling in other changes.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [X] Run `mvn verify` to make sure basic checks pass.
- [X] You have run the integration tests successfully (`mvn -Prun-its verify`). They build under Java 23 with some errors, but fail to build under 24.

      Build Summary:
      [INFO]   Passed: 84, Failed: 1, Errors: 0, Skipped: 0
      [INFO] -------------------------------------------------
      [ERROR] The following builds failed:
      [ERROR] *  mdep-779-analyze-only-verbose-shows-class-names/pom.xml

This IT test passes without the analyzer update. I'll take a look later when I have time to see if I see whats failing, tho I'm unfamiliar with both code bases.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
