### PR TITLE
Fix - markersDirectory is not working when unpack goal is executed from command line 

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -55,7 +55,9 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
     /**
      * Directory to store flag files after unpack
      */
-    @Parameter(defaultValue = "${project.build.directory}/dependency-maven-plugin-markers")
+    @Parameter(
+            property = "markersDirectory",
+            defaultValue = "${project.build.directory}/dependency-maven-plugin-markers")
     private File markersDirectory;
 
     /**


### PR DESCRIPTION
fixes #536 

Property attribute is missing in @Parameter annotation from markersDirectory attribute in UnpackMojo due to which its not working from command line.