### PR TITLE
Re-run failed tests and redirect outputs from tests to file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,8 @@ under the License.
         <configuration>
           <!-- Need more heap space in order to run the unit tests !-->
           <argLine>-Xmx512m</argLine>
+          <rerunFailingTestsCount>2</rerunFailingTestsCount>
+          <redirectTestOutputToFile>true</redirectTestOutputToFile>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
some test are flaky, try to re-run it make build more stable

tests generate many debug outputs, it is not needed by default
