### PR TITLE
Ignore Mockito 5.x and SLF4j 2.x by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
       # Jetty >=10 requires Java 11+
       - dependency-name: "org.eclipse.jetty:*"
         versions: [">= 10.0"]
+      # Mockito >=5 requires Java 11+
+      - dependency-name: "org.mockito:*"
+        versions: [">= 5.0.0"]
+      # Maven 3 so use SLF4J 1.7.x
+      - dependency-name: "org.slf4j:*"
+        versions: [">= 2.0.0"]
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Ignored dependencies should be manage by configuration, we have possibility to set it per branch.

Ignoring by closing PR or comments - ignore for all current and future branches.
