### PR TITLE
Only log dependency classpath when no property/file output is specified

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
@@ -91,12 +91,14 @@ public class BuildClasspathMojo extends AbstractDependencyFilterMojo implements 
 
     /**
      * If defined, the name of a property to which the classpath string will be written.
+     * If neither this nor the outputFile parameter is set, the classpath will be logged at INFO level.
      */
     @Parameter(property = "mdep.outputProperty")
     private String outputProperty;
 
     /**
-     * The file to write the classpath string. If undefined, it just prints the classpath as [INFO].
+     * If defined, the file to which the classpath string will be written.
+     * If neither this nor the outputProperty parameter is set, the classpath will be logged at INFO level.
      */
     @Parameter(property = "mdep.outputFile")
     private File outputFile;
@@ -237,15 +239,18 @@ public class BuildClasspathMojo extends AbstractDependencyFilterMojo implements 
             }
         }
 
-        if (outputFile == null) {
-            getLog().info("Dependencies classpath:" + System.lineSeparator() + cpString);
-        } else {
+        if (outputFile != null) {
             if (regenerateFile || !isUpToDate(cpString)) {
                 storeClasspathFile(cpString, outputFile);
             } else {
                 this.getLog().info("Skipped writing classpath file '" + outputFile + "'.  No changes found.");
             }
         }
+
+        if (outputProperty == null && outputFile == null) {
+            getLog().info("Dependencies classpath:" + System.lineSeparator() + cpString);
+        }
+
         if (attach) {
             attachFile(cpString);
         }


### PR DESCRIPTION
When invoking the `build-classpath` mojo with `outputProperty` but without `outputFile`, it logs the complete classpath at `INFO` to the build log. In our case that produces an **enormously** long log message.

Interestingly this is not the case when the `outputFile` is set. This seems to be quite arbitrary.

After doing some code archaeology, I think this behavior was never intended to work this way:
- When the mojo was conceived, there only was the `outputFile` property. So the user had the choice: Either set the `outputFile` property or have the classpath logged as INFO.
- At one point the `outputProperty` parameter was added: https://github.com/apache/maven-dependency-plugin/commit/deec581c9cb22346021b94a0e35621f6ab3ea0cc. This retained the original behavior: If neither `outputProperty` nor `outputFile` was set, the classpath would be logged at INFO.
- At a later point in time, the code was changed to allow `outputProperty` and `outputFile` to be specified at the same time: https://github.com/apache/maven-dependency-plugin/commit/96ad4a0f2f1abd7be0a356d3f539c5d8530bd5d7. This change introduced the current (and in my opinion unintended) behavior.

This PR fixes the issue by only logging the classpath at INFO level when neither `outputProperty` nor `outputFile` is set. This makes the behavior consistent regardless of which output method is chosen.

Note: Previously we used the `<silent>true</silent>` option as a workaround. However, since this has been deprecated there is not good way of achieving a sane behaviour without completely disabling logging for a build.

---

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
