### PR TITLE
Added ability to provide arbitrary dependencies to properties mojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
@@ -20,11 +20,13 @@ package org.apache.maven.plugins.dependency;
 
 import javax.inject.Inject;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -68,7 +70,7 @@ public class PropertiesMojo extends AbstractMojo {
 
     /**
      * Main entry into mojo. Gets the list of dependencies and iterates through setting a property for each artifact.
-     *
+     * Gets the list of declared plugin's dependencies and iterates through setting a property for each artifact.
      * @throws MojoExecutionException with a message if an error occurs
      */
     @Override
@@ -85,6 +87,21 @@ public class PropertiesMojo extends AbstractMojo {
                     .setProperty(
                             artifact.getDependencyConflictId(),
                             artifact.getFile().getAbsolutePath());
+        }
+
+        PluginDescriptor pluginDescriptor = (PluginDescriptor) getPluginContext().get("pluginDescriptor");
+
+        if (pluginDescriptor != null) {
+            List<Artifact> pluginArtifacts = pluginDescriptor.getArtifacts();
+            
+            if (pluginArtifacts != null) {
+                for (Artifact artifact : pluginArtifacts) {
+                    this.project.getProperties()
+                            .setProperty(
+                                    artifact.getDependencyConflictId(),
+                                    artifact.getFile().getAbsolutePath());
+                }
+            }
         }
     }
 

--- a/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
@@ -1,28 +1,47 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Copyright (c) 2016, 2025, Gluon and/or its affiliates.
+ * Copyright (c) 2021, 2025, Pascal Treilhes and/or its affiliates.
+ * Copyright (c) 2012, 2014, Oracle and/or its affiliates.
+ * All rights reserved. Use is subject to license terms.
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * This file is available and licensed under the following license:
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *  - Neither the name of Oracle Corporation and Gluon nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 package org.apache.maven.plugins.dependency;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.dependency.testUtils.stubs.DependencyProjectStub;
 import org.apache.maven.project.MavenProject;
 
@@ -75,6 +94,39 @@ public class TestPropertiesMojo extends AbstractDependencyMojoTestCase {
             File artifactFile = artifact.getFile();
             assertNotNull(artifact.getDependencyConflictId());
             assertTrue(artifactFile.isFile());
+        }
+    }
+
+    /**
+     * tests the proper discovery and configuration of the mojo for plugin dependencies
+     * Each plugin dependency should set a property in the project
+     * @throws Exception in case of errors
+     */
+    public void testSetPropertiesForPluginDependencies() throws Exception {
+        File testPom = new File(getBasedir(), "target/test-classes/unit/properties-test/plugin-config.xml");
+        PropertiesMojo mojo = (PropertiesMojo) lookupMojo("properties", testPom);
+
+        assertNotNull(mojo);
+        MavenProject project = (MavenProject) getVariableValueFromObject(mojo, "project");
+        assertNotNull(project);
+
+        Set<Artifact> artifacts = this.stubFactory.getScopedArtifacts();
+        Set<Artifact> directArtifacts = this.stubFactory.getReleaseAndSnapshotArtifacts();
+        artifacts.addAll(directArtifacts);
+
+        PluginDescriptor pluginDescriptor = new PluginDescriptor();
+        pluginDescriptor.setArtifacts(new ArrayList<>());
+        Map pluginContext = new HashMap<>();
+        pluginContext.put("pluginDescriptor", pluginDescriptor);
+        mojo.setPluginContext(pluginContext);
+
+        mojo.execute();
+
+        for (Artifact artifact : artifacts) {
+            File artifactFile = artifact.getFile();
+            String depId = artifact.getDependencyConflictId();
+            assertTrue(project.getProperties().containsKey(depId));
+            assertTrue(project.getProperties().getProperty(depId).equals(artifactFile.getAbsolutePath()));
         }
     }
 }


### PR DESCRIPTION
This PR allows providing arbitrary dependencies to project properties through the plugin’s declared dependencies.
My main use case for this feature is the ability to patch a Java module with a dependency that is outside of the project’s dependency tree (mainly to solve duplicate package name).

See sample below
```

    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-dependency-plugin</artifactId>
                <executions>
                    <execution>
                        <id>resolve-jar-path</id>
                        <goals>
                            <goal>properties</goal>
                        </goals>
                    </execution>
                </executions>
                <dependencies>
                    <dependency>
                        <groupId>com.somegroup</groupId>
                        <artifactId>someartifact</artifactId>
                        <version>someversion</version>
                    </dependency>
                </dependencies>
            </plugin>

            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <configuration>
                    <compilerArgs>
                        <arg>--patch-module</arg>
                        <arg>module.to.patch=${com.somegroup:someartifact:jar}</arg>
                    </compilerArgs>
                </configuration>
            </plugin>
        </plugins>
    </build>

```
- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
