### PR TITLE
Added ability to provide arbitrary dependencies to properties mojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.dependency;
 
 import javax.inject.Inject;
 
+import java.util.List;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -29,7 +30,10 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.dependency.utils.ParamArtifact;
+import org.apache.maven.plugins.dependency.utils.ResolverUtil;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
 
 /**
  * Goal that sets a property pointing to the artifact file for each project dependency. For each dependency (direct and
@@ -53,9 +57,12 @@ public class PropertiesMojo extends AbstractMojo {
      */
     private final MavenProject project;
 
+    private final ResolverUtil resolverUtil;
+    
     @Inject
-    public PropertiesMojo(MavenProject project) {
+    public PropertiesMojo(MavenProject project, ResolverUtil resolverUtil) {
         this.project = project;
+        this.resolverUtil = resolverUtil;
     }
 
     /**
@@ -65,10 +72,33 @@ public class PropertiesMojo extends AbstractMojo {
      */
     @Parameter(property = "mdep.skip", defaultValue = "false")
     private boolean skip;
+    
+    /**
+     * Extra artifacts that can be provided to the plugin. For each artifact in this list a property will be set
+     * similar to the project artifacts discovered. This allows callers to supply additional
+     * resolved dependencies for which properties pointing to the artifact file shall be created.
+     *
+     * Example usage in plugin configuration:
+     * <pre>
+     * &lt;extraArtifacts&gt;
+     *   &lt;extraArtifact&gt;
+     *      &lt;artifact&gt;org.example:my-artifact:jar:1.0&lt;/artifact&gt;
+     *   &lt;/extraArtifact&gt;
+     *   &lt;extraArtifact&gt;
+     *      &lt;groupId&gt;org.example&lt;/groupId&gt;
+     *      &lt;artifactId&gt;my-artifact&lt;/artifactId&gt;
+     *      &lt;version&gt;1.0&lt;/version&gt;
+     *   &lt;/extraArtifact&gt;
+     * &lt;/extraArtifacts&gt;
+     * </pre>
+     * @since 3.10.1
+     */
+    @Parameter
+    private List<ParamArtifact> extraArtifacts;
 
     /**
      * Main entry into mojo. Gets the list of dependencies and iterates through setting a property for each artifact.
-     *
+     * Gets the list of declared plugin's extra artifacts and iterates through setting a property for each artifact.
      * @throws MojoExecutionException with a message if an error occurs
      */
     @Override
@@ -86,6 +116,28 @@ public class PropertiesMojo extends AbstractMojo {
                             artifact.getDependencyConflictId(),
                             artifact.getFile().getAbsolutePath());
         }
+
+        if (extraArtifacts != null) {
+            try {
+                for (ParamArtifact paramArtifact : extraArtifacts) {
+
+                    if (!paramArtifact.isDataSet()) {
+                        throw new MojoExecutionException("You must specify an artifact OR GAV separately");
+                    }
+
+                    org.eclipse.aether.artifact.Artifact artifact = resolverUtil.createArtifactFromParams(paramArtifact);
+                    artifact = resolverUtil.resolveArtifact(artifact, project.getRemoteProjectRepositories());
+
+                    this.project
+                            .getProperties()
+                            .setProperty(
+                                    toConflictId(artifact),
+                                    artifact.getFile().getAbsolutePath());
+                }
+            } catch (ArtifactResolutionException e) {
+                throw new MojoExecutionException("Couldn't download artifact: " + e.getMessage(), e);
+            }
+        }
     }
 
     /**
@@ -93,5 +145,15 @@ public class PropertiesMojo extends AbstractMojo {
      */
     public boolean isSkip() {
         return skip;
+    }
+
+    private String toConflictId(org.eclipse.aether.artifact.Artifact artifact) {
+        // The conflict ID is the same as the one used by Maven's Artifact class, which is groupId:artifactId:type[:classifier]
+        StringBuilder sb = new StringBuilder();
+        sb.append(artifact.getGroupId()).append(":").append(artifact.getArtifactId()).append(":").append(artifact.getExtension());
+        if (artifact.getClassifier() != null && !artifact.getClassifier().isEmpty()) {
+            sb.append(":").append(artifact.getClassifier());
+        }
+        return sb.toString();
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
@@ -58,7 +58,7 @@ public class PropertiesMojo extends AbstractMojo {
     private final MavenProject project;
 
     private final ResolverUtil resolverUtil;
-    
+
     @Inject
     public PropertiesMojo(MavenProject project, ResolverUtil resolverUtil) {
         this.project = project;
@@ -72,7 +72,7 @@ public class PropertiesMojo extends AbstractMojo {
      */
     @Parameter(property = "mdep.skip", defaultValue = "false")
     private boolean skip;
-    
+
     /**
      * Extra artifacts that can be provided to the plugin. For each artifact in this list a property will be set
      * similar to the project artifacts discovered. This allows callers to supply additional
@@ -125,14 +125,14 @@ public class PropertiesMojo extends AbstractMojo {
                         throw new MojoExecutionException("You must specify an artifact OR GAV separately");
                     }
 
-                    org.eclipse.aether.artifact.Artifact artifact = resolverUtil.createArtifactFromParams(paramArtifact);
+                    org.eclipse.aether.artifact.Artifact artifact =
+                            resolverUtil.createArtifactFromParams(paramArtifact);
                     artifact = resolverUtil.resolveArtifact(artifact, project.getRemoteProjectRepositories());
 
                     this.project
                             .getProperties()
                             .setProperty(
-                                    toConflictId(artifact),
-                                    artifact.getFile().getAbsolutePath());
+                                    toConflictId(artifact), artifact.getFile().getAbsolutePath());
                 }
             } catch (ArtifactResolutionException e) {
                 throw new MojoExecutionException("Couldn't download artifact: " + e.getMessage(), e);
@@ -148,9 +148,14 @@ public class PropertiesMojo extends AbstractMojo {
     }
 
     private String toConflictId(org.eclipse.aether.artifact.Artifact artifact) {
-        // The conflict ID is the same as the one used by Maven's Artifact class, which is groupId:artifactId:type[:classifier]
+        // The conflict ID is the same as the one used by Maven's Artifact class, which is
+        // groupId:artifactId:type[:classifier]
         StringBuilder sb = new StringBuilder();
-        sb.append(artifact.getGroupId()).append(":").append(artifact.getArtifactId()).append(":").append(artifact.getExtension());
+        sb.append(artifact.getGroupId())
+                .append(":")
+                .append(artifact.getArtifactId())
+                .append(":")
+                .append(artifact.getExtension());
         if (artifact.getClassifier() != null && !artifact.getClassifier().isEmpty()) {
             sb.append(":").append(artifact.getClassifier());
         }

--- a/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
@@ -23,27 +23,30 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 
 import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoExtension;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.plugins.dependency.utils.ParamArtifact;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.ReflectionUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-@MojoTest
-public class TestPropertiesMojo {
+@MojoTest(realRepositorySession = true)
+class TestPropertiesMojo {
 
     @Inject
     private MavenProject project;
 
     @Test
     @InjectMojo(goal = "properties")
-    public void testSetProperties(PropertiesMojo mojo) throws Exception {
+    void testSetProperties(PropertiesMojo mojo) throws Exception {
 
         Artifact artifact1 = Mockito.mock(Artifact.class);
         Artifact artifact2 = Mockito.mock(Artifact.class);
@@ -62,5 +65,46 @@ public class TestPropertiesMojo {
         // Verify that properties are set correctly
         assertTrue(project.getProperties().getProperty("group1:artifact1").endsWith("artifact1.jar"));
         assertTrue(project.getProperties().getProperty("group2:artifact2").endsWith("artifact2.jar"));
+    }
+
+    /**
+     * tests the proper discovery and configuration of the mojo for extra artifacts
+     * Each artifact should be resolved and set a property in the project
+     * @throws Exception in case of errors
+     */
+    @Test
+    @InjectMojo(goal = "properties")
+    void testSetPropertiesForExtractArtifacts(PropertiesMojo mojo) throws Exception {
+        
+        String depId1 = "org.apache.commons:commons-lang3:jar";
+        String depId2 = "org.apache.commons:commons-collections4:jar";
+        
+        ParamArtifact a1 = new ParamArtifact();
+        a1.setGroupId("org.apache.commons");
+        a1.setArtifactId("commons-lang3");
+        a1.setVersion("3.6");
+
+        ParamArtifact a2 = new ParamArtifact();
+        a2.setGroupId("org.apache.commons");
+        a2.setArtifactId("commons-collections4");
+        a2.setVersion("4.4");
+
+        List<ParamArtifact> artifacts = Arrays.asList(a1, a2);
+
+        // 3. Inject into private field
+        ReflectionUtils.setVariableValueInObject(
+            mojo,
+            "extraArtifacts",
+            artifacts
+        );
+        
+        mojo.execute();
+
+        assertTrue(project.getProperties().containsKey(depId1));
+        assertTrue(new File(project.getProperties().getProperty(depId1)).exists());
+
+        assertTrue(project.getProperties().containsKey(depId2));
+        assertTrue(new File(project.getProperties().getProperty(depId1)).exists());
+
     }
 }

--- a/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/TestPropertiesMojo.java
@@ -75,10 +75,10 @@ class TestPropertiesMojo {
     @Test
     @InjectMojo(goal = "properties")
     void testSetPropertiesForExtractArtifacts(PropertiesMojo mojo) throws Exception {
-        
+
         String depId1 = "org.apache.commons:commons-lang3:jar";
         String depId2 = "org.apache.commons:commons-collections4:jar";
-        
+
         ParamArtifact a1 = new ParamArtifact();
         a1.setGroupId("org.apache.commons");
         a1.setArtifactId("commons-lang3");
@@ -92,12 +92,8 @@ class TestPropertiesMojo {
         List<ParamArtifact> artifacts = Arrays.asList(a1, a2);
 
         // 3. Inject into private field
-        ReflectionUtils.setVariableValueInObject(
-            mojo,
-            "extraArtifacts",
-            artifacts
-        );
-        
+        ReflectionUtils.setVariableValueInObject(mojo, "extraArtifacts", artifacts);
+
         mojo.execute();
 
         assertTrue(project.getProperties().containsKey(depId1));
@@ -105,6 +101,5 @@ class TestPropertiesMojo {
 
         assertTrue(project.getProperties().containsKey(depId2));
         assertTrue(new File(project.getProperties().getProperty(depId1)).exists());
-
     }
 }


### PR DESCRIPTION
This PR allows providing arbitrary dependencies to project properties through the plugin’s declared dependencies.
My main use case for this feature is the ability to patch a Java module with a dependency that is outside of the project’s dependency tree (mainly to solve duplicate package name).

See sample below


```

    <build>
        <plugins>
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-dependency-plugin</artifactId>
                <executions>
                    <execution>
                        <id>resolve-jar-path</id>
                        <goals>
                            <goal>properties</goal>
                        </goals>
                    </execution>
                </executions>
                <dependencies>
                    <dependency>
                        <groupId>com.somegroup</groupId>
                        <artifactId>someartifact</artifactId>
                        <version>someversion</version>
                    </dependency>
                </dependencies>
            </plugin>

            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-compiler-plugin</artifactId>
                <configuration>
                    <compilerArgs>
                        <arg>--patch-module</arg>
                        <arg>module.to.patch=${com.somegroup:someartifact:jar}</arg>
                    </compilerArgs>
                </configuration>
            </plugin>
        </plugins>
    </build>

```
- [x]  I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)