### PR TITLE
Fix `analyze-exclusions` crashes if there is no `dependencyManagement` element

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojo.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import org.apache.maven.RepositoryUtils;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -103,14 +104,21 @@ public class AnalyzeExclusionsMojo extends AbstractMojo {
 
         Map<Coordinates, Collection<Exclusion>> dependenciesWithExclusions = new HashMap<>();
 
-        project.getDependencyManagement().getDependencies().forEach(dependency -> {
-            Collection<Exclusion> exclusions = getExclusionsForDependency(dependency);
-            if (!exclusions.isEmpty()) {
-                dependenciesWithExclusions
-                        .computeIfAbsent(coordinates(dependency), d -> new ArrayList<>())
-                        .addAll(exclusions);
+        DependencyManagement depMgt = project.getDependencyManagement();
+        if (depMgt != null) {
+            List<Dependency> depMgtDependencies = depMgt.getDependencies();
+
+            if (depMgtDependencies != null) {
+                depMgtDependencies.forEach(dependency -> {
+                    Collection<Exclusion> exclusions = getExclusionsForDependency(dependency);
+                    if (!exclusions.isEmpty()) {
+                        dependenciesWithExclusions
+                                .computeIfAbsent(coordinates(dependency), d -> new ArrayList<>())
+                                .addAll(exclusions);
+                    }
+                });
             }
-        });
+        }
 
         project.getDependencies().forEach(dependency -> {
             Collection<Exclusion> exclusions = getExclusionsForDependency(dependency);

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Stream;
 
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.plugin.testing.InjectMojo;
@@ -45,9 +44,6 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -203,21 +199,28 @@ class AnalyzeExclusionsMojoTest {
      *
      * @see <a href="https://github.com/apache/maven-dependency-plugin/issues/1474">Issue</a>
      */
-    @ParameterizedTest
-    @MethodSource
-    @NullSource
+    @Test
     @InjectMojo(goal = "analyze-exclusions")
-    void testMojoWithSpecifiedProjectDependencyManagement(
-            DependencyManagement dependencyManagement, AnalyzeExclusionsMojo mojo) {
-        when(project.getDependencyManagement()).thenReturn(dependencyManagement);
+    void testMojoWithProjectDependencyManagementNull(AnalyzeExclusionsMojo mojo) {
+        // Default behavior specified explicitly for clarity
+        when(project.getDependencyManagement()).thenReturn(null);
 
         assertThatCode(mojo::execute).doesNotThrowAnyException();
     }
 
-    static Stream<DependencyManagement> testMojoWithSpecifiedProjectDependencyManagement() {
+    /**
+     * Nullability behavior of {@link MavenProject#getDependencyManagement} is not documented, test mojo with both {@code null}
+     * and non-{@code null} outputs
+     *
+     * @see <a href="https://github.com/apache/maven-dependency-plugin/issues/1474">Issue</a>
+     */
+    @Test
+    @InjectMojo(goal = "analyze-exclusions")
+    void testMojoWithProjectDependencyManagementEmpty(AnalyzeExclusionsMojo mojo) {
         DependencyManagement dependencyManagement = mock(DependencyManagement.class);
-        when(dependencyManagement.getDependencies()).thenReturn(Collections.emptyList());
-        return Stream.of(dependencyManagement);
+        lenient().when(dependencyManagement.getDependencies()).thenReturn(Collections.emptyList());
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
     }
 
     private Dependency dependency(String groupId, String artifactId) {

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.maven.api.di.Provides;
 import org.apache.maven.api.plugin.testing.InjectMojo;
@@ -31,6 +32,7 @@ import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
@@ -43,6 +45,9 @@ import org.eclipse.aether.artifact.DefaultArtifact;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -51,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -82,8 +88,6 @@ class AnalyzeExclusionsMojoTest {
         when(project.getGroupId()).thenReturn("testGroupId");
         when(project.getArtifactId()).thenReturn("testArtifactId");
         when(project.getVersion()).thenReturn("1.0.0");
-
-        when(project.getDependencyManagement()).thenReturn(null);
 
         lenient().when(mavenSession.getRepositorySession()).thenReturn(new DefaultRepositorySystemSession());
     }
@@ -191,6 +195,29 @@ class AnalyzeExclusionsMojoTest {
         mojo.execute();
 
         verify(testLog).warn("projectName defines following unnecessary excludes");
+    }
+
+    /**
+     * Nullability behavior of {@link MavenProject#getDependencyManagement} is not documented, test mojo with both {@code null}
+     * and non-{@code null} outputs
+     * 
+     * @see <a href="https://github.com/apache/maven-dependency-plugin/issues/1474">Issue</a>
+     */
+    @ParameterizedTest
+    @MethodSource
+    @NullSource
+    @InjectMojo(goal = "analyze-exclusions")
+    void testMojoWithSpecifiedProjectDependencyManagement(DependencyManagement dependencyManagement,
+            AnalyzeExclusionsMojo mojo) {
+        when(project.getDependencyManagement()).thenReturn(dependencyManagement);
+
+        assertThatCode(mojo::execute).doesNotThrowAnyException();
+    }
+
+    static Stream<DependencyManagement> testMojoWithSpecifiedProjectDependencyManagement() {
+        DependencyManagement dependencyManagement = mock(DependencyManagement.class);
+        when(dependencyManagement.getDependencies()).thenReturn(Collections.emptyList());
+        return Stream.of(dependencyManagement);
     }
 
     private Dependency dependency(String groupId, String artifactId) {

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -200,15 +200,15 @@ class AnalyzeExclusionsMojoTest {
     /**
      * Nullability behavior of {@link MavenProject#getDependencyManagement} is not documented, test mojo with both {@code null}
      * and non-{@code null} outputs
-     * 
+     *
      * @see <a href="https://github.com/apache/maven-dependency-plugin/issues/1474">Issue</a>
      */
     @ParameterizedTest
     @MethodSource
     @NullSource
     @InjectMojo(goal = "analyze-exclusions")
-    void testMojoWithSpecifiedProjectDependencyManagement(DependencyManagement dependencyManagement,
-            AnalyzeExclusionsMojo mojo) {
+    void testMojoWithSpecifiedProjectDependencyManagement(
+            DependencyManagement dependencyManagement, AnalyzeExclusionsMojo mojo) {
         when(project.getDependencyManagement()).thenReturn(dependencyManagement);
 
         assertThatCode(mojo::execute).doesNotThrowAnyException();

--- a/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/exclusion/AnalyzeExclusionsMojoTest.java
@@ -31,7 +31,6 @@ import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.Exclusion;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputSource;
@@ -52,7 +51,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -85,9 +83,7 @@ class AnalyzeExclusionsMojoTest {
         when(project.getArtifactId()).thenReturn("testArtifactId");
         when(project.getVersion()).thenReturn("1.0.0");
 
-        DependencyManagement dependencyManagement = mock(DependencyManagement.class);
-        when(dependencyManagement.getDependencies()).thenReturn(Collections.emptyList());
-        when(project.getDependencyManagement()).thenReturn(dependencyManagement);
+        when(project.getDependencyManagement()).thenReturn(null);
 
         lenient().when(mavenSession.getRepositorySession()).thenReturn(new DefaultRepositorySystemSession());
     }


### PR DESCRIPTION
As reported in https://github.com/apache/maven-dependency-plugin/issues/1474, when executed on a project without a `dependencyManagement` tag defined, an exception is thrown:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.10.0:analyze-exclusions (default-cli) on project reproducer: Execution default-cli of goal org.apache.maven.plugins:maven-dependency-plugin:3.10.0:analyze-exclusions failed: Cannot invoke "org.apache.maven.model.DependencyManagement.getDependencies()" because the return value of "org.apache.maven.project.MavenProject.getDependencyManagement()" is null -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.10.0:analyze-exclusions (default-cli) on project reproducer: Execution default-cli of goal org.apache.maven.plugins:maven-dependency-plugin:3.10.0:analyze-exclusions failed: Cannot invoke "org.apache.maven.model.DependencyManagement.getDependencies()" because the return value of "org.apache.maven.project.MavenProject.getDependencyManagement()" is null
{...}
Caused by: java.lang.NullPointerException: Cannot invoke "org.apache.maven.model.DependencyManagement.getDependencies()" because the return value of "org.apache.maven.project.MavenProject.getDependencyManagement()" is null
    at org.apache.maven.plugins.dependency.exclusion.AnalyzeExclusionsMojo.execute (AnalyzeExclusionsMojo.java:106)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo (DefaultBuildPluginManager.java:126)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute2 (MojoExecutor.java:328)
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:316)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:212)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:174)
    at org.apache.maven.lifecycle.internal.MojoExecutor.access$000 (MojoExecutor.java:75)
    at org.apache.maven.lifecycle.internal.MojoExecutor$1.run (MojoExecutor.java:162)
    at org.apache.maven.plugin.DefaultMojosExecutionStrategy.execute (DefaultMojosExecutionStrategy.java:39)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:159)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:105)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:73)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:53)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:118)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:261)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:173)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:101)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:919)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:285)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:207)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
```

When executing `analyze-exclusions`, we simply assume `getDependencyManagement` returns non-`null`. Whereas in other mojos a more cautious approach is taken, e.g.: https://github.com/apache/maven-dependency-plugin/blob/a99bc570747b2623a4f3e5ca5a3dc98e379bd58b/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeDepMgt.java#L118-L123

Updated this mojo (and corresponding test) to suit.

Fixes: https://github.com/apache/maven-dependency-plugin/issues/1474

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
