### PR TITLE
Add dependency:add, dependency:remove and dependency:search goals using DomTrip

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,11 @@ under the License.
     <!-- domtrip -->
     <dependency>
       <groupId>eu.maveniverse.maven.domtrip</groupId>
+      <artifactId>domtrip-core</artifactId>
+      <version>${domtripVersion}</version>
+    </dependency>
+    <dependency>
+      <groupId>eu.maveniverse.maven.domtrip</groupId>
       <artifactId>domtrip-maven</artifactId>
       <version>${domtripVersion}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@ under the License.
     <slf4jVersion>1.7.36</slf4jVersion>
     <jettyVersion>9.4.58.v20250814</jettyVersion>
     <mockito.version>4.11.0</mockito.version>
+    <domtripVersion>0.6.0</domtripVersion>
     <plexus-archiver.version>4.11.0</plexus-archiver.version>
     <pluginTestingVersion>3.5.1</pluginTestingVersion>
 
@@ -196,6 +197,13 @@ under the License.
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-i18n</artifactId>
       <version>1.1.0</version>
+    </dependency>
+
+    <!-- domtrip -->
+    <dependency>
+      <groupId>eu.maveniverse.maven.domtrip</groupId>
+      <artifactId>domtrip-maven</artifactId>
+      <version>${domtripVersion}</version>
     </dependency>
 
     <!-- shared -->
@@ -319,7 +327,6 @@ under the License.
       <groupId>org.glassfish</groupId>
       <artifactId>jakarta.json</artifactId>
       <version>2.0.1</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugin-testing</groupId>

--- a/src/it/projects/add-dependency-align-properties/invoker.properties
+++ b/src/it/projects/add-dependency-align-properties/invoker.properties
@@ -15,5 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-gav=org.junit.jupiter:junit-jupiter-api:5.10.0
-scope=test
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-align-properties/pom.xml
+++ b/src/it/projects/add-dependency-align-properties/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Test project that uses version properties but NO managed dependencies.
+     When align=true (default), adding a new dependency should detect the
+     property naming convention (.version suffix) and create a property,
+     but should NOT use managed dependencies. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency-align-properties</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <junit.version>4.13.2</junit.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <commons-io.version>2.15.0</commons-io.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/add-dependency-align-properties/test.properties
+++ b/src/it/projects/add-dependency-align-properties/test.properties
@@ -15,5 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-gav=org.junit.jupiter:junit-jupiter-api:5.10.0
-scope=test
+gav=com.google.guava:guava:33.0.0-jre

--- a/src/it/projects/add-dependency-align-properties/verify.groovy
+++ b/src/it/projects/add-dependency-align-properties/verify.groovy
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pomText = new File( basedir, "pom.xml" ).text
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+
+// Align should detect that all 3 existing deps use .version property convention
+// and create a guava.version property for the new dependency
+assert pomText.contains( '<guava.version>33.0.0-jre</guava.version>' ) :
+    "Should have created guava.version property (matching existing .version suffix convention)"
+assert pomText.contains( '${guava.version}' ) :
+    "Dependency version should reference \${guava.version}"
+
+// Align should NOT use managed dependencies (all existing deps have explicit versions)
+def managedDeps = pom.dependencyManagement.dependencies.dependency
+assert managedDeps.isEmpty() :
+    "Should NOT have created dependencyManagement (existing deps all have versions)"
+
+// Verify the dependency was added to regular dependencies
+def dep = pom.dependencies.dependency.find { it.artifactId == 'guava' }
+assert dep != null : "guava should be in dependencies"
+
+// Verify existing deps are preserved
+assert pom.dependencies.dependency.size() == 4 : "Should have 4 dependencies total"
+assert pomText.contains( '${junit.version}' ) : "Existing junit property ref preserved"
+assert pomText.contains( '${slf4j.version}' ) : "Existing slf4j property ref preserved"
+assert pomText.contains( '${commons-io.version}' ) : "Existing commons-io property ref preserved"
+
+return true

--- a/src/it/projects/add-dependency-align/invoker.properties
+++ b/src/it/projects/add-dependency-align/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-align/pom.xml
+++ b/src/it/projects/add-dependency-align/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Test project that already uses managed dependencies with version properties.
+     When align=true (default), adding a new dependency should follow the same conventions:
+     - version property with .version suffix
+     - managed dependency in dependencyManagement
+     - version-less entry in dependencies -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency-align</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <junit.version>4.13.2</junit.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <commons-io.version>2.15.0</commons-io.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <!-- All version-less: project uses managed deps pattern -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/add-dependency-align/test.properties
+++ b/src/it/projects/add-dependency-align/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=com.google.guava:guava:33.0.0-jre

--- a/src/it/projects/add-dependency-align/verify.groovy
+++ b/src/it/projects/add-dependency-align/verify.groovy
@@ -18,7 +18,7 @@
  */
 
 def pomText = new File( basedir, "pom.xml" ).text
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 
 // Verify auto-detection created a version property following the .version convention
 assert pomText.contains( '<guava.version>33.0.0-jre</guava.version>' ) :

--- a/src/it/projects/add-dependency-align/verify.groovy
+++ b/src/it/projects/add-dependency-align/verify.groovy
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pomText = new File( basedir, "pom.xml" ).text
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+
+// Verify auto-detection created a version property following the .version convention
+assert pomText.contains( '<guava.version>33.0.0-jre</guava.version>' ) :
+    "Should have created guava.version property (matching existing .version suffix pattern)"
+
+// Verify managed dependency was added with property reference
+def managedDeps = pom.dependencyManagement.dependencies.dependency
+def managedGuava = managedDeps.find { it.artifactId == 'guava' }
+assert managedGuava != null : "guava should be in dependencyManagement"
+assert pomText.contains( '${guava.version}' ) :
+    "Managed dependency version should reference \${guava.version}"
+
+// Verify version-less dependency was added to regular dependencies
+def deps = pom.dependencies.dependency
+def guava = deps.find { it.artifactId == 'guava' }
+assert guava != null : "guava should be in dependencies"
+
+// Verify the regular dependency is version-less (version comes from managed deps)
+// In the raw XML, the dependency entry should NOT have a <version> element
+def depsSection = pomText.substring( pomText.lastIndexOf( '<dependencies>' ) )
+def guavaBlock = depsSection.substring( depsSection.indexOf( 'guava' ) )
+guavaBlock = guavaBlock.substring( 0, guavaBlock.indexOf( '</dependency>' ) )
+assert !guavaBlock.contains( '<version>' ) :
+    "Regular dependency should be version-less (managed by dependencyManagement)"
+
+// Verify existing dependencies are preserved
+assert deps.find { it.artifactId == 'junit' } != null
+assert deps.find { it.artifactId == 'slf4j-api' } != null
+assert deps.find { it.artifactId == 'commons-io' } != null
+
+return true

--- a/src/it/projects/add-dependency-managed/invoker.properties
+++ b/src/it/projects/add-dependency-managed/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-managed/pom.xml
+++ b/src/it/projects/add-dependency-managed/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency-managed</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+</project>

--- a/src/it/projects/add-dependency-managed/test.properties
+++ b/src/it/projects/add-dependency-managed/test.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=org.apache.commons:commons-lang3:3.12.0
+managed=true
+align=false

--- a/src/it/projects/add-dependency-managed/verify.groovy
+++ b/src/it/projects/add-dependency-managed/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 
 // Verify dependency was added to dependencyManagement
 def managedDeps = pom.dependencyManagement.dependencies.dependency

--- a/src/it/projects/add-dependency-managed/verify.groovy
+++ b/src/it/projects/add-dependency-managed/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+
+// Verify dependency was added to dependencyManagement
+def managedDeps = pom.dependencyManagement.dependencies.dependency
+def lang3 = managedDeps.find { it.groupId == 'org.apache.commons' && it.artifactId == 'commons-lang3' }
+assert lang3 != null : "commons-lang3 should be in dependencyManagement"
+assert lang3.version == '3.12.0'
+
+// Verify it was NOT added to regular dependencies
+def regularDeps = pom.dependencies.dependency
+def regularLang3 = regularDeps.find { it.groupId == 'org.apache.commons' && it.artifactId == 'commons-lang3' }
+assert regularLang3.isEmpty() : "commons-lang3 should NOT be in regular dependencies"
+
+return true

--- a/src/it/projects/add-dependency-multimodule-dash/invoker.properties
+++ b/src/it/projects/add-dependency-multimodule-dash/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-multimodule-dash/parent/pom.xml
+++ b/src/it/projects/add-dependency-multimodule-dash/parent/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Parent POM using dash-version property convention (e.g., Camel style).
+     Properties are named artifactId-version instead of artifactId.version. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>multimodule-dash-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <junit-version>4.13.2</junit-version>
+    <slf4j-api-version>2.0.9</slf4j-api-version>
+    <commons-io-version>2.15.0</commons-io-version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j-api-version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io-version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/src/it/projects/add-dependency-multimodule-dash/pom.xml
+++ b/src/it/projects/add-dependency-multimodule-dash/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Child module using dash-version property convention (like Camel).
+     Running dependency:add should detect the -version suffix pattern
+     from parent's managed deps and create guava-version property. -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.dependency.its</groupId>
+    <artifactId>multimodule-dash-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multimodule-dash-child</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/add-dependency-multimodule-dash/test.properties
+++ b/src/it/projects/add-dependency-multimodule-dash/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=com.google.guava:guava:33.0.0-jre

--- a/src/it/projects/add-dependency-multimodule-dash/verify.groovy
+++ b/src/it/projects/add-dependency-multimodule-dash/verify.groovy
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// --- Verify parent POM was modified ---
+def parentPomText = new File( basedir, "parent/pom.xml" ).text
+def parentPom = new groovy.xml.XmlSlurper().parse( new File( basedir, "parent/pom.xml" ) )
+
+// 1. Property should use dash-version convention (matching existing pattern)
+assert parentPomText.contains( '<guava-version>33.0.0-jre</guava-version>' ) :
+    "Parent should have guava-version property (dash convention)"
+
+// 2. Managed dependency should reference property with dash convention
+def managedDeps = parentPom.dependencyManagement.dependencies.dependency
+def managedGuava = managedDeps.find { it.artifactId == 'guava' }
+assert managedGuava != null : "guava should be in parent's dependencyManagement"
+assert parentPomText.contains( '${guava-version}' ) :
+    "Parent managed dependency version should reference \${guava-version}"
+
+// 3. Existing managed dependencies should be preserved
+assert managedDeps.find { it.artifactId == 'junit' } != null : "junit should still be managed"
+assert managedDeps.find { it.artifactId == 'slf4j-api' } != null : "slf4j-api should still be managed"
+assert managedDeps.find { it.artifactId == 'commons-io' } != null : "commons-io should still be managed"
+assert parentPomText.contains( '${junit-version}' ) : "Existing junit-version property ref preserved"
+assert parentPomText.contains( '${slf4j-api-version}' ) : "Existing slf4j-api-version property ref preserved"
+
+// --- Verify child POM was modified ---
+def childPomText = new File( basedir, "pom.xml" ).text
+def childPom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+
+// 4. Version-less dependency should have been added to child
+def childDeps = childPom.dependencies.dependency
+def childGuava = childDeps.find { it.artifactId == 'guava' }
+assert childGuava != null : "guava should be in child dependencies"
+
+// 5. The child dependency should be version-less
+def childDepsSection = childPomText.substring( childPomText.lastIndexOf( '<dependencies>' ) )
+def guavaBlock = childDepsSection.substring( childDepsSection.indexOf( 'guava' ) )
+guavaBlock = guavaBlock.substring( 0, guavaBlock.indexOf( '</dependency>' ) )
+assert !guavaBlock.contains( '<version>' ) :
+    "Child dependency should be version-less (managed by parent)"
+
+// 6. Existing child dependencies should be preserved
+assert childDeps.size() == 4 : "Child should now have 4 dependencies"
+
+return true

--- a/src/it/projects/add-dependency-multimodule/invoker.properties
+++ b/src/it/projects/add-dependency-multimodule/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-multimodule/parent/pom.xml
+++ b/src/it/projects/add-dependency-multimodule/parent/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>multimodule-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+
+  <properties>
+    <junit.version>4.13.2</junit.version>
+    <slf4j.version>2.0.9</slf4j.version>
+    <commons-io.version>2.15.0</commons-io.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>${junit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/src/it/projects/add-dependency-multimodule/pom.xml
+++ b/src/it/projects/add-dependency-multimodule/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!-- Child module that inherits managed dependencies from parent.
+     All existing deps are version-less (delegated to parent's dependencyManagement).
+     Running dependency:add should detect this pattern and:
+     1. Add guava.version property to parent/pom.xml
+     2. Add managed dependency for guava to parent/pom.xml
+     3. Add version-less dependency for guava to this POM -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.plugins.dependency.its</groupId>
+    <artifactId>multimodule-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>multimodule-child</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/add-dependency-multimodule/test.properties
+++ b/src/it/projects/add-dependency-multimodule/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=com.google.guava:guava:33.0.0-jre

--- a/src/it/projects/add-dependency-multimodule/verify.groovy
+++ b/src/it/projects/add-dependency-multimodule/verify.groovy
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// --- Verify parent POM was modified ---
+def parentPomText = new File( basedir, "parent/pom.xml" ).text
+def parentPom = new groovy.xml.XmlSlurper().parse( new File( basedir, "parent/pom.xml" ) )
+
+// 1. Property should have been added to parent
+assert parentPomText.contains( '<guava.version>33.0.0-jre</guava.version>' ) :
+    "Parent should have guava.version property"
+
+// 2. Managed dependency should have been added to parent with property reference
+def managedDeps = parentPom.dependencyManagement.dependencies.dependency
+def managedGuava = managedDeps.find { it.artifactId == 'guava' }
+assert managedGuava != null : "guava should be in parent's dependencyManagement"
+assert parentPomText.contains( '${guava.version}' ) :
+    "Parent managed dependency version should reference \${guava.version}"
+
+// 3. Existing managed dependencies should be preserved
+assert managedDeps.find { it.artifactId == 'junit' } != null : "junit should still be managed"
+assert managedDeps.find { it.artifactId == 'slf4j-api' } != null : "slf4j-api should still be managed"
+assert managedDeps.find { it.artifactId == 'commons-io' } != null : "commons-io should still be managed"
+assert parentPomText.contains( '${junit.version}' ) : "Existing junit property ref preserved"
+assert parentPomText.contains( '${slf4j.version}' ) : "Existing slf4j property ref preserved"
+
+// --- Verify child POM was modified ---
+def childPomText = new File( basedir, "pom.xml" ).text
+def childPom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+
+// 4. Version-less dependency should have been added to child
+def childDeps = childPom.dependencies.dependency
+def childGuava = childDeps.find { it.artifactId == 'guava' }
+assert childGuava != null : "guava should be in child dependencies"
+
+// 5. The child dependency should be version-less
+// Find the guava block in the child's <dependencies> section and verify no <version>
+def childDepsSection = childPomText.substring( childPomText.lastIndexOf( '<dependencies>' ) )
+def guavaBlock = childDepsSection.substring( childDepsSection.indexOf( 'guava' ) )
+guavaBlock = guavaBlock.substring( 0, guavaBlock.indexOf( '</dependency>' ) )
+assert !guavaBlock.contains( '<version>' ) :
+    "Child dependency should be version-less (managed by parent)"
+
+// 6. Existing child dependencies should be preserved
+assert childDeps.size() == 4 : "Child should now have 4 dependencies"
+assert childDeps.find { it.artifactId == 'junit' } != null
+assert childDeps.find { it.artifactId == 'slf4j-api' } != null
+assert childDeps.find { it.artifactId == 'commons-io' } != null
+
+// --- Verify build log ---
+def buildLog = new File( basedir, "build.log" ).text
+assert buildLog.contains( 'Added/updated com.google.guava:guava:33.0.0-jre' ) :
+    "Log should confirm managed dep added"
+assert buildLog.contains( 'Added com.google.guava:guava' ) :
+    "Log should confirm version-less dep added"
+
+return true

--- a/src/it/projects/add-dependency-property/invoker.properties
+++ b/src/it/projects/add-dependency-property/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-property/pom.xml
+++ b/src/it/projects/add-dependency-property/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency-property</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+</project>

--- a/src/it/projects/add-dependency-property/test.properties
+++ b/src/it/projects/add-dependency-property/test.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=com.google.guava:guava:33.0.0-jre
+propertyName=guava.version
+align=false

--- a/src/it/projects/add-dependency-property/verify.groovy
+++ b/src/it/projects/add-dependency-property/verify.groovy
@@ -29,7 +29,7 @@ assert pomText.contains( '${guava.version}' ) :
     "Dependency version should reference \${guava.version}"
 
 // Also verify via XML parsing that the dependency exists
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def dep = pom.dependencies.dependency.find { it.artifactId == 'guava' }
 assert dep != null : "guava dependency should have been added"
 

--- a/src/it/projects/add-dependency-property/verify.groovy
+++ b/src/it/projects/add-dependency-property/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Read the raw POM text to verify the property reference (XmlSlurper resolves properties)
+def pomText = new File( basedir, "pom.xml" ).text
+
+// Verify property was created
+assert pomText.contains( '<guava.version>33.0.0-jre</guava.version>' ) :
+    "Property guava.version should be defined"
+
+// Verify dependency version references the property
+assert pomText.contains( '${guava.version}' ) :
+    "Dependency version should reference \${guava.version}"
+
+// Also verify via XML parsing that the dependency exists
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def dep = pom.dependencies.dependency.find { it.artifactId == 'guava' }
+assert dep != null : "guava dependency should have been added"
+
+return true

--- a/src/it/projects/add-dependency-scope/invoker.properties
+++ b/src/it/projects/add-dependency-scope/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency-scope/pom.xml
+++ b/src/it/projects/add-dependency-scope/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency-scope</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+</project>

--- a/src/it/projects/add-dependency-scope/test.properties
+++ b/src/it/projects/add-dependency-scope/test.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=org.junit.jupiter:junit-jupiter-api:5.10.0
+scope=test
+align=false

--- a/src/it/projects/add-dependency-scope/verify.groovy
+++ b/src/it/projects/add-dependency-scope/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def deps = pom.dependencies.dependency
 
 def dep = deps.find { it.groupId == 'org.junit.jupiter' && it.artifactId == 'junit-jupiter-api' }

--- a/src/it/projects/add-dependency-scope/verify.groovy
+++ b/src/it/projects/add-dependency-scope/verify.groovy
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def deps = pom.dependencies.dependency
+
+def dep = deps.find { it.groupId == 'org.junit.jupiter' && it.artifactId == 'junit-jupiter-api' }
+assert dep != null : "junit-jupiter-api should have been added"
+assert dep.version == '5.10.0'
+assert dep.scope == 'test' : "scope should be 'test'"
+
+return true

--- a/src/it/projects/add-dependency/invoker.properties
+++ b/src/it/projects/add-dependency/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:add

--- a/src/it/projects/add-dependency/pom.xml
+++ b/src/it/projects/add-dependency/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>add-dependency</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <!-- existing dependency to verify it's preserved -->
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/add-dependency/test.properties
+++ b/src/it/projects/add-dependency/test.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=org.apache.commons:commons-lang3:3.12.0
+align=false

--- a/src/it/projects/add-dependency/test.properties
+++ b/src/it/projects/add-dependency/test.properties
@@ -16,4 +16,3 @@
 # under the License.
 
 gav=org.apache.commons:commons-lang3:3.12.0
-align=false

--- a/src/it/projects/add-dependency/verify.groovy
+++ b/src/it/projects/add-dependency/verify.groovy
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def deps = pom.dependencies.dependency
+
+// Verify existing dependency is preserved
+def junit = deps.find { it.groupId == 'junit' && it.artifactId == 'junit' }
+assert junit != null : "Existing junit dependency should be preserved"
+assert junit.version == '4.13.2'
+assert junit.scope == 'test'
+
+// Verify new dependency was added
+def lang3 = deps.find { it.groupId == 'org.apache.commons' && it.artifactId == 'commons-lang3' }
+assert lang3 != null : "commons-lang3 dependency should have been added"
+assert lang3.version == '3.12.0'
+
+// Verify build log
+def buildLog = new File( basedir, "build.log" ).text
+assert buildLog.contains( 'Added/updated org.apache.commons:commons-lang3:3.12.0' )
+
+return true

--- a/src/it/projects/add-dependency/verify.groovy
+++ b/src/it/projects/add-dependency/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def deps = pom.dependencies.dependency
 
 // Verify existing dependency is preserved

--- a/src/it/projects/remove-dependency-managed/invoker.properties
+++ b/src/it/projects/remove-dependency-managed/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:remove

--- a/src/it/projects/remove-dependency-managed/pom.xml
+++ b/src/it/projects/remove-dependency-managed/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>remove-dependency-managed</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.13.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.9</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+</project>

--- a/src/it/projects/remove-dependency-managed/test.properties
+++ b/src/it/projects/remove-dependency-managed/test.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=junit:junit
+managed=true

--- a/src/it/projects/remove-dependency-managed/verify.groovy
+++ b/src/it/projects/remove-dependency-managed/verify.groovy
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def managedDeps = pom.dependencyManagement.dependencies.dependency
+
+// Verify junit was removed from dependencyManagement
+def junit = managedDeps.find { it.groupId == 'junit' && it.artifactId == 'junit' }
+assert junit.isEmpty() : "junit should have been removed from dependencyManagement"
+
+// Verify slf4j-api is still there
+def slf4j = managedDeps.find { it.groupId == 'org.slf4j' && it.artifactId == 'slf4j-api' }
+assert slf4j != null : "slf4j-api should be preserved in dependencyManagement"
+assert slf4j.version == '2.0.9'
+
+return true

--- a/src/it/projects/remove-dependency-managed/verify.groovy
+++ b/src/it/projects/remove-dependency-managed/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def managedDeps = pom.dependencyManagement.dependencies.dependency
 
 // Verify junit was removed from dependencyManagement

--- a/src/it/projects/remove-dependency-not-found/invoker.properties
+++ b/src/it/projects/remove-dependency-not-found/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:remove
+invoker.buildResult = failure

--- a/src/it/projects/remove-dependency-not-found/pom.xml
+++ b/src/it/projects/remove-dependency-not-found/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>remove-dependency-not-found</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/remove-dependency-not-found/test.properties
+++ b/src/it/projects/remove-dependency-not-found/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=junit:junit

--- a/src/it/projects/remove-dependency-not-found/verify.groovy
+++ b/src/it/projects/remove-dependency-not-found/verify.groovy
@@ -22,7 +22,7 @@ def buildLog = new File( basedir, "build.log" ).text
 assert buildLog.contains( 'not found in' ) : "Should report dependency not found"
 
 // POM should be unchanged
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def deps = pom.dependencies.dependency
 assert deps.size() == 1 : "POM should still have exactly 1 dependency"
 assert deps[0].artifactId == 'slf4j-api'

--- a/src/it/projects/remove-dependency-not-found/verify.groovy
+++ b/src/it/projects/remove-dependency-not-found/verify.groovy
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Build is expected to fail
+def buildLog = new File( basedir, "build.log" ).text
+assert buildLog.contains( 'not found in' ) : "Should report dependency not found"
+
+// POM should be unchanged
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def deps = pom.dependencies.dependency
+assert deps.size() == 1 : "POM should still have exactly 1 dependency"
+assert deps[0].artifactId == 'slf4j-api'
+
+return true

--- a/src/it/projects/remove-dependency/invoker.properties
+++ b/src/it/projects/remove-dependency/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:remove

--- a/src/it/projects/remove-dependency/pom.xml
+++ b/src/it/projects/remove-dependency/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>remove-dependency</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.9</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/src/it/projects/remove-dependency/test.properties
+++ b/src/it/projects/remove-dependency/test.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+gav=junit:junit

--- a/src/it/projects/remove-dependency/verify.groovy
+++ b/src/it/projects/remove-dependency/verify.groovy
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def pom = new groovy.xml.XmlSlurper().parse( new File( basedir, "pom.xml" ) )
 def deps = pom.dependencies.dependency
 
 // Verify junit was removed

--- a/src/it/projects/remove-dependency/verify.groovy
+++ b/src/it/projects/remove-dependency/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def pom = new XmlSlurper().parse( new File( basedir, "pom.xml" ) )
+def deps = pom.dependencies.dependency
+
+// Verify junit was removed
+def junit = deps.find { it.groupId == 'junit' && it.artifactId == 'junit' }
+assert junit.isEmpty() : "junit dependency should have been removed"
+
+// Verify slf4j-api is still there
+def slf4j = deps.find { it.groupId == 'org.slf4j' && it.artifactId == 'slf4j-api' }
+assert slf4j != null : "slf4j-api dependency should be preserved"
+assert slf4j.version == '2.0.9'
+
+// Verify build log
+def buildLog = new File( basedir, "build.log" ).text
+assert buildLog.contains( 'Removed junit:junit' )
+
+return true

--- a/src/it/projects/search-dependency/invoker.properties
+++ b/src/it/projects/search-dependency/invoker.properties
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:search
+# This IT requires network access to Maven Central search API
+invoker.os.family = !offline

--- a/src/it/projects/search-dependency/pom.xml
+++ b/src/it/projects/search-dependency/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>search-dependency</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+</project>

--- a/src/it/projects/search-dependency/test.properties
+++ b/src/it/projects/search-dependency/test.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+query=g:org.apache.commons AND a:commons-lang3
+rows=5

--- a/src/it/projects/search-dependency/verify.groovy
+++ b/src/it/projects/search-dependency/verify.groovy
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def buildLog = new File( basedir, "build.log" ).text
+
+// Verify search was executed
+assert buildLog.contains( 'Searching Maven Central' ) : "Should show search message"
+
+// Verify results contain commons-lang3
+assert buildLog.contains( 'org.apache.commons' ) : "Results should contain org.apache.commons"
+assert buildLog.contains( 'commons-lang3' ) : "Results should contain commons-lang3"
+
+// Verify table header was printed
+assert buildLog.contains( 'GroupId' ) : "Should print table header"
+assert buildLog.contains( 'ArtifactId' ) : "Should print table header"
+
+return true

--- a/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
@@ -24,6 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.Element;
@@ -41,16 +43,24 @@ import org.sonatype.plexus.build.incremental.BuildContext;
  * Adds or updates a dependency in the project's {@code pom.xml}.
  * Uses DomTrip for lossless XML editing that preserves formatting, comments, and whitespace.
  *
- * <p>If the dependency already exists (matched by groupId, artifactId, type, and classifier),
- * its version is updated. If the version is a property reference ({@code ${...}}), the property
- * value is updated instead.</p>
+ * <p>By default ({@code align=true}), this mojo auto-detects the project's dependency management
+ * conventions by analyzing existing dependencies:</p>
+ * <ul>
+ *   <li>If the project uses {@code <dependencyManagement>} (most deps are version-less),
+ *       the version is added to the managed section and a version-less entry to {@code <dependencies>}.</li>
+ *   <li>If existing versions use property references ({@code ${...}}), a property is created
+ *       following the detected naming convention.</li>
+ *   <li>The managed dependency POM is discovered by walking the parent chain.</li>
+ * </ul>
+ *
+ * <p>Explicit flags ({@code -Dmanaged}, {@code -DuseProperty}, {@code -DpropertyName}) override
+ * auto-detected conventions.</p>
  *
  * <p>Examples:</p>
  * <pre>
  * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
  * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dscope=compile
- * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dmanaged
- * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -DuseProperty
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dalign=false -Dmanaged
  * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -DpropertyName=guava.version
  * </pre>
  *
@@ -67,9 +77,10 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
 
     /**
      * When {@code true}, add to {@code <dependencyManagement>} instead of {@code <dependencies>}.
+     * Overrides auto-detection from {@code align}.
      */
-    @Parameter(property = "managed", defaultValue = "false")
-    private boolean managed;
+    @Parameter(property = "managed")
+    private Boolean managed;
 
     /**
      * The dependency scope (e.g., {@code compile}, {@code test}, {@code provided}, {@code runtime}, {@code system}).
@@ -79,20 +90,31 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
     private String scope;
 
     /**
-     * When {@code true}, store the version in a property (e.g., {@code ${artifactId.version}})
-     * and reference it from the dependency's {@code <version>} element.
-     * The property name is derived from the artifactId unless {@link #propertyName} is set.
+     * When {@code true}, store the version in a property and reference it from the dependency's
+     * {@code <version>} element. Overrides auto-detection from {@code align}.
      */
-    @Parameter(property = "useProperty", defaultValue = "false")
-    private boolean useProperty;
+    @Parameter(property = "useProperty")
+    private Boolean useProperty;
 
     /**
      * Explicit property name to use for the version (implies {@code useProperty=true}).
-     * For example, {@code -DpropertyName=guava.version} creates {@code <guava.version>33.0.0-jre</guava.version>}
-     * in {@code <properties>} and sets the dependency version to {@code ${guava.version}}.
+     * Overrides auto-detection from {@code align}.
      */
     @Parameter(property = "propertyName")
     private String propertyName;
+
+    /**
+     * When {@code true} (the default), auto-detect the project's dependency management conventions
+     * by analyzing existing dependencies. Detected conventions are:
+     * <ul>
+     *   <li>Whether to use managed dependencies (based on whether existing deps are version-less)</li>
+     *   <li>Whether to use version properties (based on existing {@code ${...}} references)</li>
+     *   <li>Property naming convention (e.g., {@code artifactId.version} vs {@code version.artifactId})</li>
+     *   <li>Which POM to add managed dependencies to (walks parent chain)</li>
+     * </ul>
+     */
+    @Parameter(property = "align", defaultValue = "true")
+    private boolean align;
 
     @Inject
     public AddDependencyMojo(MavenSession session, BuildContext buildContext, MavenProject project) {
@@ -102,61 +124,124 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
     @Override
     protected void doExecute() throws MojoExecutionException, MojoFailureException {
         Coordinates coords = parseCoordinates(gav);
-        File pomFile = getProject().getFile();
 
-        boolean wantProperty = useProperty || propertyName != null;
-        if (wantProperty && (coords.version() == null || coords.version().isEmpty())) {
+        Conventions conventions;
+        if (align) {
+            conventions = detectConventions(coords);
+        } else {
+            conventions = new Conventions();
+        }
+
+        // Explicit flags override detected conventions
+        boolean effectiveManaged = managed != null ? managed : conventions.useManaged;
+        boolean effectiveUseProperty =
+                propertyName != null || (useProperty != null ? useProperty : conventions.useProperty);
+        String effectivePropertyName = propertyName != null ? propertyName : conventions.propertyName;
+        File managedPomFile = conventions.managedPomFile;
+
+        if (effectiveUseProperty
+                && (coords.version() == null || coords.version().isEmpty())) {
             throw new MojoFailureException("Version is required when using property-based versioning");
         }
 
         try {
-            Document doc = Document.of(pomFile.toPath());
-            PomEditor editor = new PomEditor(doc);
-
-            Coordinates effectiveCoords = coords;
-            if (wantProperty) {
-                String propName = propertyName != null ? propertyName : coords.artifactId() + ".version";
-                // Use property reference as the version in the dependency element
-                effectiveCoords = Coordinates.of(
-                        coords.groupId(),
-                        coords.artifactId(),
-                        "${" + propName + "}",
-                        coords.classifier(),
-                        coords.type());
-                // Create or update the property with the actual version value
-                editor.properties().updateProperty(true, propName, coords.version());
-            }
-
-            boolean changed;
-            if (managed) {
-                changed = editor.dependencies().updateManagedDependency(true, effectiveCoords);
+            if (effectiveManaged && managedPomFile != null) {
+                addManagedDependency(coords, managedPomFile, effectiveUseProperty, effectivePropertyName);
+                addVersionlessDependency(coords);
             } else {
-                changed = editor.dependencies().updateDependency(true, effectiveCoords);
-            }
-
-            if (scope != null && !scope.isEmpty()) {
-                setDependencyScope(editor, effectiveCoords);
-                changed = true;
-            }
-
-            if (changed || wantProperty) {
-                try (OutputStream os = Files.newOutputStream(pomFile.toPath())) {
-                    doc.toXml(os);
-                }
-                String section = managed ? "<dependencyManagement>" : "<dependencies>";
-                getLog().info("Added/updated " + coords.toGAV() + " in " + section);
-            } else {
-                getLog().info("No changes needed for " + coords.toGAV());
+                addDependencyToCurrentPom(coords, effectiveManaged, effectiveUseProperty, effectivePropertyName);
             }
         } catch (IOException e) {
-            throw new MojoExecutionException("Failed to modify POM file: " + pomFile, e);
+            throw new MojoExecutionException("Failed to modify POM file", e);
+        }
+    }
+
+    private void addManagedDependency(
+            Coordinates coords, File managedPomFile, boolean effectiveUseProperty, String effectivePropertyName)
+            throws IOException {
+        Document managedDoc = Document.of(managedPomFile.toPath());
+        PomEditor managedEditor = new PomEditor(managedDoc);
+
+        Coordinates managedCoords = coords;
+        if (effectiveUseProperty && coords.version() != null) {
+            String propName = effectivePropertyName != null ? effectivePropertyName : coords.artifactId() + ".version";
+            managedCoords = coords.withVersion("${" + propName + "}");
+            managedEditor.properties().updateProperty(true, propName, coords.version());
+        }
+
+        boolean changed = managedEditor.dependencies().updateManagedDependency(true, managedCoords);
+        if (changed) {
+            try (OutputStream os = Files.newOutputStream(managedPomFile.toPath())) {
+                managedDoc.toXml(os);
+            }
+            getLog().info("Added/updated " + coords.toGAV() + " in <dependencyManagement> of " + managedPomFile);
+        }
+    }
+
+    private void addVersionlessDependency(Coordinates coords) throws IOException {
+        File pomFile = getProject().getFile();
+        Document doc = Document.of(pomFile.toPath());
+        PomEditor editor = new PomEditor(doc);
+
+        // Add dependency without version (version comes from managed deps)
+        Coordinates versionless =
+                Coordinates.of(coords.groupId(), coords.artifactId(), null, coords.classifier(), coords.type());
+        boolean changed = editor.dependencies().updateDependency(true, versionless);
+
+        if (scope != null && !scope.isEmpty()) {
+            setDependencyScope(editor, versionless);
+            changed = true;
+        }
+
+        if (changed) {
+            try (OutputStream os = Files.newOutputStream(pomFile.toPath())) {
+                doc.toXml(os);
+            }
+            getLog().info("Added " + coords.toGA() + " (version-less) in <dependencies> of " + pomFile);
+        }
+    }
+
+    private void addDependencyToCurrentPom(
+            Coordinates coords, boolean effectiveManaged, boolean effectiveUseProperty, String effectivePropertyName)
+            throws IOException {
+        File pomFile = getProject().getFile();
+        Document doc = Document.of(pomFile.toPath());
+        PomEditor editor = new PomEditor(doc);
+
+        Coordinates effectiveCoords = coords;
+        if (effectiveUseProperty && coords.version() != null) {
+            String propName = effectivePropertyName != null ? effectivePropertyName : coords.artifactId() + ".version";
+            effectiveCoords = coords.withVersion("${" + propName + "}");
+            editor.properties().updateProperty(true, propName, coords.version());
+        }
+
+        boolean changed;
+        if (effectiveManaged) {
+            changed = editor.dependencies().updateManagedDependency(true, effectiveCoords);
+        } else {
+            changed = editor.dependencies().updateDependency(true, effectiveCoords);
+        }
+
+        if (scope != null && !scope.isEmpty()) {
+            setDependencyScope(editor, effectiveCoords);
+            changed = true;
+        }
+
+        if (changed || effectiveUseProperty) {
+            try (OutputStream os = Files.newOutputStream(pomFile.toPath())) {
+                doc.toXml(os);
+            }
+            String section = effectiveManaged ? "<dependencyManagement>" : "<dependencies>";
+            getLog().info("Added/updated " + coords.toGAV() + " in " + section);
+        } else {
+            getLog().info("No changes needed for " + coords.toGAV());
         }
     }
 
     private void setDependencyScope(PomEditor editor, Coordinates coords) {
         Element root = editor.document().root();
         Element depsContainer;
-        if (managed) {
+        if (managed != null && managed) {
             Element dm = editor.findChildElement(root, "dependencyManagement");
             depsContainer = dm != null ? editor.findChildElement(dm, "dependencies") : null;
         } else {
@@ -171,6 +256,227 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
                         editor.updateOrCreateChildElement(dep, "scope", scope);
                     });
         }
+    }
+
+    // --- Convention detection ---
+
+    static class Conventions {
+        boolean useManaged;
+        boolean useProperty;
+        String propertyName; // null means use detected pattern to generate
+        String propertyPattern; // e.g., "suffix:.version" or "prefix:version."
+        File managedPomFile;
+
+        String derivePropertyName(String artifactId) {
+            if (propertyName != null) {
+                return propertyName;
+            }
+            if (propertyPattern != null) {
+                if (propertyPattern.startsWith("suffix:")) {
+                    return artifactId + propertyPattern.substring("suffix:".length());
+                } else if (propertyPattern.startsWith("prefix:")) {
+                    return propertyPattern.substring("prefix:".length()) + artifactId;
+                }
+            }
+            return artifactId + ".version";
+        }
+    }
+
+    private Conventions detectConventions(Coordinates coords) {
+        Conventions conventions = new Conventions();
+        MavenProject project = getProject();
+
+        // 1. Analyze the current POM's dependencies for property and managed dep patterns
+        File pomFile = project.getFile();
+        if (pomFile != null && pomFile.exists()) {
+            try {
+                Document doc = Document.of(pomFile.toPath());
+                analyzePropertyPatterns(doc, conventions);
+                analyzeManagedDependencyUsage(doc, conventions);
+            } catch (Exception e) {
+                getLog().debug("Could not analyze POM conventions: " + e.getMessage());
+            }
+        }
+
+        // 2. Find the POM that owns <dependencyManagement> by walking the parent chain
+        if (conventions.useManaged) {
+            conventions.managedPomFile = findManagedDependenciesPom(project);
+            if (conventions.managedPomFile == null) {
+                // No parent with managed deps found on disk — fall back to current POM
+                conventions.managedPomFile = pomFile;
+            }
+        }
+
+        // Use detected pattern for property name
+        if (conventions.useProperty) {
+            conventions.propertyName = conventions.derivePropertyName(coords.artifactId());
+        }
+
+        if (getLog().isDebugEnabled()) {
+            getLog().debug("Detected conventions: useManaged=" + conventions.useManaged + ", useProperty="
+                    + conventions.useProperty + ", propertyPattern=" + conventions.propertyPattern
+                    + ", managedPomFile=" + conventions.managedPomFile);
+        }
+
+        return conventions;
+    }
+
+    private void analyzePropertyPatterns(Document doc, Conventions conventions) {
+        Element root = doc.root();
+        Map<String, Integer> patternCounts = new HashMap<>();
+        int propertyVersions = 0;
+        int totalVersions = 0;
+
+        // Scan <dependencies> and <dependencyManagement><dependencies>
+        scanVersionPatterns(root, "dependencies", patternCounts, new int[] {0, 0});
+        Element dm = root.childElement("dependencyManagement").orElse(null);
+        if (dm != null) {
+            int[] counts = {0, 0}; // [propertyVersions, totalVersions]
+            scanVersionPatterns(dm, "dependencies", patternCounts, counts);
+            propertyVersions += counts[0];
+            totalVersions += counts[1];
+        }
+
+        // Also count from <dependencies> directly
+        int[] directCounts = {0, 0};
+        scanVersionPatterns(root, "dependencies", patternCounts, directCounts);
+        propertyVersions += directCounts[0];
+        totalVersions += directCounts[1];
+
+        // If majority of versioned deps use properties, adopt that convention
+        if (totalVersions > 0 && propertyVersions * 2 >= totalVersions) {
+            conventions.useProperty = true;
+            // Find dominant pattern
+            String dominantPattern = null;
+            int maxCount = 0;
+            for (Map.Entry<String, Integer> entry : patternCounts.entrySet()) {
+                if (entry.getValue() > maxCount) {
+                    maxCount = entry.getValue();
+                    dominantPattern = entry.getKey();
+                }
+            }
+            conventions.propertyPattern = dominantPattern;
+        }
+    }
+
+    private void scanVersionPatterns(
+            Element parent, String containerName, Map<String, Integer> patternCounts, int[] counts) {
+        Element container = parent.childElement(containerName).orElse(null);
+        if (container == null) {
+            return;
+        }
+        container.childElements("dependency").forEach(dep -> {
+            String artifactId = dep.childTextTrimmed("artifactId");
+            Element versionEl = dep.childElement("version").orElse(null);
+            if (versionEl != null) {
+                String version = versionEl.textContentTrimmed();
+                counts[1]++; // totalVersions
+                if (version != null && version.startsWith("${") && version.endsWith("}")) {
+                    counts[0]++; // propertyVersions
+                    String propName = version.substring(2, version.length() - 1);
+                    String pattern = detectPattern(propName, artifactId);
+                    if (pattern != null) {
+                        patternCounts.merge(pattern, 1, Integer::sum);
+                    }
+                }
+            }
+        });
+    }
+
+    static String detectPattern(String propertyName, String artifactId) {
+        if (artifactId == null) {
+            return null;
+        }
+        // Check suffix patterns: artifactId.version, artifactId-version, artifactIdVersion
+        if (propertyName.equals(artifactId + ".version")) {
+            return "suffix:.version";
+        }
+        if (propertyName.equals("version." + artifactId)) {
+            return "prefix:version.";
+        }
+        // Check with simplified artifactId (strip common prefixes/suffixes)
+        String simplified = simplifyArtifactId(artifactId);
+        if (!simplified.equals(artifactId)) {
+            if (propertyName.equals(simplified + ".version")) {
+                return "suffix:.version";
+            }
+            if (propertyName.equals("version." + simplified)) {
+                return "prefix:version.";
+            }
+        }
+        // Check if ends with .version or Version regardless
+        if (propertyName.endsWith(".version")) {
+            return "suffix:.version";
+        }
+        if (propertyName.endsWith("Version")) {
+            return "suffix:Version";
+        }
+        if (propertyName.startsWith("version.")) {
+            return "prefix:version.";
+        }
+        return null;
+    }
+
+    private static String simplifyArtifactId(String artifactId) {
+        // Remove common prefixes/suffixes that are often dropped in property names
+        String result = artifactId;
+        for (String prefix : new String[] {"maven-", "jakarta.", "javax."}) {
+            if (result.startsWith(prefix)) {
+                result = result.substring(prefix.length());
+            }
+        }
+        for (String suffix : new String[] {"-api", "-core", "-impl"}) {
+            if (result.endsWith(suffix)) {
+                result = result.substring(0, result.length() - suffix.length());
+            }
+        }
+        return result;
+    }
+
+    private void analyzeManagedDependencyUsage(Document doc, Conventions conventions) {
+        Element root = doc.root();
+        Element deps = root.childElement("dependencies").orElse(null);
+        if (deps == null) {
+            return;
+        }
+        int withVersion = 0;
+        int withoutVersion = 0;
+        for (Element dep :
+                (Iterable<Element>) () -> deps.childElements("dependency").iterator()) {
+            Element versionEl = dep.childElement("version").orElse(null);
+            if (versionEl != null) {
+                withVersion++;
+            } else {
+                withoutVersion++;
+            }
+        }
+        // If there are dependencies and majority are version-less, project uses managed deps
+        int total = withVersion + withoutVersion;
+        if (total > 0 && withoutVersion * 2 >= total) {
+            conventions.useManaged = true;
+        }
+    }
+
+    private File findManagedDependenciesPom(MavenProject project) {
+        MavenProject parent = project.getParent();
+        while (parent != null) {
+            File parentPom = parent.getFile();
+            if (parentPom != null && parentPom.exists()) {
+                try {
+                    Document parentDoc = Document.of(parentPom.toPath());
+                    Element root = parentDoc.root();
+                    Element dm = root.childElement("dependencyManagement").orElse(null);
+                    if (dm != null) {
+                        return parentPom;
+                    }
+                } catch (Exception e) {
+                    getLog().debug("Could not read parent POM: " + parentPom);
+                }
+            }
+            parent = parent.getParent();
+        }
+        // If no parent has dependencyManagement, use current POM
+        return project.getFile();
     }
 
     static Coordinates parseCoordinates(String gav) throws MojoFailureException {

--- a/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Element;
+import eu.maveniverse.domtrip.maven.Coordinates;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Adds or updates a dependency in the project's {@code pom.xml}.
+ * Uses DomTrip for lossless XML editing that preserves formatting, comments, and whitespace.
+ *
+ * <p>If the dependency already exists (matched by groupId, artifactId, type, and classifier),
+ * its version is updated. If the version is a property reference ({@code ${...}}), the property
+ * value is updated instead.</p>
+ *
+ * <p>Examples:</p>
+ * <pre>
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dscope=compile
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dmanaged
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -DuseProperty
+ * mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -DpropertyName=guava.version
+ * </pre>
+ *
+ * @since 3.11.0
+ */
+@Mojo(name = "add", requiresProject = true, threadSafe = true)
+public class AddDependencyMojo extends AbstractDependencyMojo {
+
+    /**
+     * The dependency coordinates: {@code groupId:artifactId[:version[:classifier[:type]]]}.
+     */
+    @Parameter(property = "gav", required = true)
+    private String gav;
+
+    /**
+     * When {@code true}, add to {@code <dependencyManagement>} instead of {@code <dependencies>}.
+     */
+    @Parameter(property = "managed", defaultValue = "false")
+    private boolean managed;
+
+    /**
+     * The dependency scope (e.g., {@code compile}, {@code test}, {@code provided}, {@code runtime}, {@code system}).
+     * If not specified, no {@code <scope>} element is added (Maven defaults to {@code compile}).
+     */
+    @Parameter(property = "scope")
+    private String scope;
+
+    /**
+     * When {@code true}, store the version in a property (e.g., {@code ${artifactId.version}})
+     * and reference it from the dependency's {@code <version>} element.
+     * The property name is derived from the artifactId unless {@link #propertyName} is set.
+     */
+    @Parameter(property = "useProperty", defaultValue = "false")
+    private boolean useProperty;
+
+    /**
+     * Explicit property name to use for the version (implies {@code useProperty=true}).
+     * For example, {@code -DpropertyName=guava.version} creates {@code <guava.version>33.0.0-jre</guava.version>}
+     * in {@code <properties>} and sets the dependency version to {@code ${guava.version}}.
+     */
+    @Parameter(property = "propertyName")
+    private String propertyName;
+
+    @Inject
+    public AddDependencyMojo(MavenSession session, BuildContext buildContext, MavenProject project) {
+        super(session, buildContext, project);
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        Coordinates coords = parseCoordinates(gav);
+        File pomFile = getProject().getFile();
+
+        boolean wantProperty = useProperty || propertyName != null;
+        if (wantProperty && (coords.version() == null || coords.version().isEmpty())) {
+            throw new MojoFailureException("Version is required when using property-based versioning");
+        }
+
+        try {
+            Document doc = Document.of(pomFile.toPath());
+            PomEditor editor = new PomEditor(doc);
+
+            Coordinates effectiveCoords = coords;
+            if (wantProperty) {
+                String propName = propertyName != null ? propertyName : coords.artifactId() + ".version";
+                // Use property reference as the version in the dependency element
+                effectiveCoords = Coordinates.of(
+                        coords.groupId(),
+                        coords.artifactId(),
+                        "${" + propName + "}",
+                        coords.classifier(),
+                        coords.type());
+                // Create or update the property with the actual version value
+                editor.properties().updateProperty(true, propName, coords.version());
+            }
+
+            boolean changed;
+            if (managed) {
+                changed = editor.dependencies().updateManagedDependency(true, effectiveCoords);
+            } else {
+                changed = editor.dependencies().updateDependency(true, effectiveCoords);
+            }
+
+            if (scope != null && !scope.isEmpty()) {
+                setDependencyScope(editor, effectiveCoords);
+                changed = true;
+            }
+
+            if (changed || wantProperty) {
+                try (OutputStream os = Files.newOutputStream(pomFile.toPath())) {
+                    doc.toXml(os);
+                }
+                String section = managed ? "<dependencyManagement>" : "<dependencies>";
+                getLog().info("Added/updated " + coords.toGAV() + " in " + section);
+            } else {
+                getLog().info("No changes needed for " + coords.toGAV());
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to modify POM file: " + pomFile, e);
+        }
+    }
+
+    private void setDependencyScope(PomEditor editor, Coordinates coords) {
+        Element root = editor.document().root();
+        Element depsContainer;
+        if (managed) {
+            Element dm = editor.findChildElement(root, "dependencyManagement");
+            depsContainer = dm != null ? editor.findChildElement(dm, "dependencies") : null;
+        } else {
+            depsContainer = editor.findChildElement(root, "dependencies");
+        }
+        if (depsContainer != null) {
+            depsContainer
+                    .childElements("dependency")
+                    .filter(coords.predicateGATC())
+                    .findFirst()
+                    .ifPresent(dep -> {
+                        editor.updateOrCreateChildElement(dep, "scope", scope);
+                    });
+        }
+    }
+
+    static Coordinates parseCoordinates(String gav) throws MojoFailureException {
+        if (gav == null || gav.trim().isEmpty()) {
+            throw new MojoFailureException("GAV must not be empty. Use -Dgav=groupId:artifactId[:version]");
+        }
+        String[] parts = gav.split(":");
+        if (parts.length < 2 || parts.length > 5) {
+            throw new MojoFailureException(
+                    "Invalid GAV format: '" + gav + "'. Expected groupId:artifactId[:version[:classifier[:type]]]");
+        }
+        String groupId = parts[0].trim();
+        String artifactId = parts[1].trim();
+        String version = parts.length >= 3 ? parts[2].trim() : null;
+        String classifier = parts.length >= 4 ? parts[3].trim() : null;
+        String type = parts.length >= 5 ? parts[4].trim() : null;
+        if (groupId.isEmpty() || artifactId.isEmpty()) {
+            throw new MojoFailureException("groupId and artifactId must not be empty");
+        }
+        if (version != null && version.isEmpty()) {
+            version = null;
+        }
+        if (classifier != null && classifier.isEmpty()) {
+            classifier = null;
+        }
+        if (type != null && type.isEmpty()) {
+            type = null;
+        }
+        return Coordinates.of(groupId, artifactId, version, classifier, type != null ? type : "jar");
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/AddDependencyMojo.java
@@ -305,6 +305,19 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
                 // No parent with managed deps found on disk — fall back to current POM
                 conventions.managedPomFile = pomFile;
             }
+
+            // 3. Also scan the managed deps POM for property patterns (the child POM
+            //    may have only version-less deps, so patterns live in the parent)
+            if (!conventions.useProperty
+                    && conventions.managedPomFile != null
+                    && !conventions.managedPomFile.equals(pomFile)) {
+                try {
+                    Document managedDoc = Document.of(conventions.managedPomFile.toPath());
+                    analyzePropertyPatterns(managedDoc, conventions);
+                } catch (Exception e) {
+                    getLog().debug("Could not analyze managed POM conventions: " + e.getMessage());
+                }
+            }
         }
 
         // Use detected pattern for property name
@@ -327,21 +340,20 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
         int propertyVersions = 0;
         int totalVersions = 0;
 
-        // Scan <dependencies> and <dependencyManagement><dependencies>
-        scanVersionPatterns(root, "dependencies", patternCounts, new int[] {0, 0});
-        Element dm = root.childElement("dependencyManagement").orElse(null);
-        if (dm != null) {
-            int[] counts = {0, 0}; // [propertyVersions, totalVersions]
-            scanVersionPatterns(dm, "dependencies", patternCounts, counts);
-            propertyVersions += counts[0];
-            totalVersions += counts[1];
-        }
-
-        // Also count from <dependencies> directly
+        // Scan <dependencies>
         int[] directCounts = {0, 0};
         scanVersionPatterns(root, "dependencies", patternCounts, directCounts);
         propertyVersions += directCounts[0];
         totalVersions += directCounts[1];
+
+        // Scan <dependencyManagement><dependencies>
+        Element dm = root.childElement("dependencyManagement").orElse(null);
+        if (dm != null) {
+            int[] counts = {0, 0};
+            scanVersionPatterns(dm, "dependencies", patternCounts, counts);
+            propertyVersions += counts[0];
+            totalVersions += counts[1];
+        }
 
         // If majority of versioned deps use properties, adopt that convention
         if (totalVersions > 0 && propertyVersions * 2 >= totalVersions) {
@@ -387,9 +399,12 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
         if (artifactId == null) {
             return null;
         }
-        // Check suffix patterns: artifactId.version, artifactId-version, artifactIdVersion
+        // Check exact suffix patterns: artifactId.version, artifactId-version
         if (propertyName.equals(artifactId + ".version")) {
             return "suffix:.version";
+        }
+        if (propertyName.equals(artifactId + "-version")) {
+            return "suffix:-version";
         }
         if (propertyName.equals("version." + artifactId)) {
             return "prefix:version.";
@@ -400,13 +415,19 @@ public class AddDependencyMojo extends AbstractDependencyMojo {
             if (propertyName.equals(simplified + ".version")) {
                 return "suffix:.version";
             }
+            if (propertyName.equals(simplified + "-version")) {
+                return "suffix:-version";
+            }
             if (propertyName.equals("version." + simplified)) {
                 return "prefix:version.";
             }
         }
-        // Check if ends with .version or Version regardless
+        // Check if ends with .version, -version, or Version regardless
         if (propertyName.endsWith(".version")) {
             return "suffix:.version";
+        }
+        if (propertyName.endsWith("-version")) {
+            return "suffix:-version";
         }
         if (propertyName.endsWith("Version")) {
             return "suffix:Version";

--- a/src/main/java/org/apache/maven/plugins/dependency/RemoveDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/RemoveDependencyMojo.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency;
+
+import javax.inject.Inject;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.file.Files;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.Coordinates;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Removes a dependency from the project's {@code pom.xml}.
+ * Uses DomTrip for lossless XML editing that preserves formatting, comments, and whitespace.
+ *
+ * @since 3.11.0
+ */
+@Mojo(name = "remove", requiresProject = true, threadSafe = true)
+public class RemoveDependencyMojo extends AbstractDependencyMojo {
+
+    /**
+     * The dependency GAV coordinates: {@code groupId:artifactId[:version[:classifier[:type]]]}.
+     * Only groupId and artifactId are used for matching.
+     */
+    @Parameter(property = "gav", required = true)
+    private String gav;
+
+    /**
+     * When {@code true}, remove from {@code <dependencyManagement>} instead of {@code <dependencies>}.
+     */
+    @Parameter(property = "managed", defaultValue = "false")
+    private boolean managed;
+
+    @Inject
+    public RemoveDependencyMojo(MavenSession session, BuildContext buildContext, MavenProject project) {
+        super(session, buildContext, project);
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        Coordinates coords = AddDependencyMojo.parseCoordinates(gav);
+        File pomFile = getProject().getFile();
+
+        try {
+            Document doc = Document.of(pomFile.toPath());
+            PomEditor editor = new PomEditor(doc);
+
+            boolean removed;
+            if (managed) {
+                removed = editor.dependencies().deleteManagedDependency(coords);
+            } else {
+                removed = editor.dependencies().deleteDependency(coords);
+            }
+
+            if (removed) {
+                try (OutputStream os = Files.newOutputStream(pomFile.toPath())) {
+                    doc.toXml(os);
+                }
+                String section = managed ? "<dependencyManagement>" : "<dependencies>";
+                getLog().info("Removed " + coords.toGA() + " from " + section);
+            } else {
+                String section = managed ? "<dependencyManagement>" : "<dependencies>";
+                throw new MojoFailureException("Dependency " + coords.toGA() + " not found in " + section + ".");
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Failed to modify POM file: " + pomFile, e);
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/SearchDependencyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/SearchDependencyMojo.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.sonatype.plexus.build.incremental.BuildContext;
+
+/**
+ * Searches Maven Central for artifacts matching a query.
+ *
+ * <p>Uses the Sonatype Central Search API (Solr). Supports free-text search
+ * and field-based queries using Solr syntax.</p>
+ *
+ * <p>Examples:</p>
+ * <pre>
+ * mvn dependency:search -Dquery=guava
+ * mvn dependency:search -Dquery="g:com.google.guava AND a:guava"
+ * mvn dependency:search -Dquery=guava -Drows=5
+ * </pre>
+ *
+ * @since 3.11.0
+ */
+@Mojo(name = "search", requiresProject = false, threadSafe = true)
+public class SearchDependencyMojo extends AbstractDependencyMojo {
+
+    private static final String SEARCH_URL = "https://central.sonatype.com/solrsearch/select";
+
+    /**
+     * The search query. Supports free-text (e.g., {@code guava}) or Solr field syntax
+     * (e.g., {@code g:com.google.guava AND a:guava}).
+     */
+    @Parameter(property = "query", required = true)
+    private String query;
+
+    /**
+     * Maximum number of results to return.
+     */
+    @Parameter(property = "rows", defaultValue = "20")
+    private int rows;
+
+    @Inject
+    public SearchDependencyMojo(MavenSession session, BuildContext buildContext, MavenProject project) {
+        super(session, buildContext, project);
+    }
+
+    @Override
+    protected void doExecute() throws MojoExecutionException, MojoFailureException {
+        getLog().info("Searching Maven Central for: " + query);
+
+        try {
+            String url = buildSearchUrl();
+            JsonObject response = executeSearch(url);
+            JsonObject responseBody = response.getJsonObject("response");
+            int totalHits = responseBody.getInt("numFound");
+            JsonArray docs = responseBody.getJsonArray("docs");
+
+            if (docs.isEmpty()) {
+                getLog().info("No results found.");
+                return;
+            }
+
+            getLog().info("Found " + totalHits + " result(s), showing " + docs.size() + ":");
+            getLog().info("");
+
+            // Print header
+            String format = "%-40s %-30s %-15s";
+            getLog().info(String.format(format, "GroupId", "ArtifactId", "Version"));
+            getLog().info(String.format(format, dashes(40), dashes(30), dashes(15)));
+
+            for (int i = 0; i < docs.size(); i++) {
+                JsonObject doc = docs.getJsonObject(i);
+                String groupId = doc.getString("g", "");
+                String artifactId = doc.getString("a", "");
+                String version = doc.getString("latestVersion", doc.getString("v", ""));
+                getLog().info(String.format(format, groupId, artifactId, version));
+            }
+
+            if (totalHits > docs.size()) {
+                getLog().info("");
+                getLog().info("... and " + (totalHits - docs.size()) + " more. Use -Drows=N to see more results.");
+            }
+        } catch (IOException e) {
+            throw new MojoExecutionException("Search failed: " + e.getMessage(), e);
+        }
+    }
+
+    private String buildSearchUrl() throws UnsupportedEncodingException {
+        return SEARCH_URL + "?q=" + URLEncoder.encode(query, "UTF-8") + "&rows=" + rows + "&wt=json";
+    }
+
+    private JsonObject executeSearch(String url) throws IOException, MojoExecutionException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+        connection.setRequestMethod("GET");
+        connection.setRequestProperty("Accept", "application/json");
+        connection.setConnectTimeout(10_000);
+        connection.setReadTimeout(10_000);
+
+        int status = connection.getResponseCode();
+        if (status != 200) {
+            throw new MojoExecutionException("Search API returned HTTP " + status);
+        }
+
+        try (InputStream is = connection.getInputStream();
+                JsonReader reader = Json.createReader(is)) {
+            return reader.readObject();
+        }
+    }
+
+    private static String dashes(int count) {
+        StringBuilder sb = new StringBuilder(count);
+        for (int i = 0; i < count; i++) {
+            sb.append('-');
+        }
+        return sb.toString();
+    }
+}

--- a/src/site/apt/examples/adding-removing-dependencies.apt.vm
+++ b/src/site/apt/examples/adding-removing-dependencies.apt.vm
@@ -1,0 +1,164 @@
+~~ Licensed to the Apache Software Foundation (ASF) under one
+~~ or more contributor license agreements.  See the NOTICE file
+~~ distributed with this work for additional information
+~~ regarding copyright ownership.  The ASF licenses this file
+~~ to you under the Apache License, Version 2.0 (the
+~~ "License"); you may not use this file except in compliance
+~~ with the License.  You may obtain a copy of the License at
+~~
+~~ http://www.apache.org/licenses/LICENSE-2.0
+~~
+~~ Unless required by applicable law or agreed to in writing,
+~~ software distributed under the License is distributed on an
+~~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+~~ KIND, either express or implied.  See the License for the
+~~ specific language governing permissions and limitations
+~~ under the License.
+
+  ------
+  Adding and Removing Dependencies
+  ------
+  Apache Maven Team
+  ------
+  2024-01-01
+  ------
+
+Adding and Removing Dependencies
+
+%{toc|fromDepth=2}
+
+* Adding a dependency
+
+  The <<<dependency:add>>> goal adds a dependency to the project's <<<pom.xml>>> using lossless XML editing
+  that preserves formatting, comments, and whitespace.
+
+  The coordinates are specified using the <<<gav>>> parameter in the format
+  <<<groupId:artifactId[:version[:classifier[:type]]]>>>.
+
+** Basic usage
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
+---
+
+  This adds the following to your <<<pom.xml>>>:
+
++---+
+<dependencies>
+    <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.0.0-jre</version>
+    </dependency>
+</dependencies>
++---+
+
+** Adding with a scope
+
+  Use the <<<scope>>> parameter to set the dependency scope:
+
+---
+mvn dependency:add -Dgav=junit:junit:4.13.2 -Dscope=test
+---
+
+** Convention auto-detection (align)
+
+  By default, <<<align=true>>> causes the goal to analyze existing dependencies and follow the
+  project's conventions:
+
+  * <<Managed dependencies>>: If most existing dependencies are version-less (delegated to
+    <<<\<dependencyManagement\>>>>), the new dependency is added the same way.
+
+  * <<Version properties>>: If existing versions use property references (e.g., <<<$\{guava.version\}>>>),
+    a property is created following the detected naming convention.
+
+  * <<Parent POM>>: In multi-module projects, managed dependencies and properties are added to the
+    appropriate parent POM.
+
+  []
+
+  For example, in a project where all dependencies use <<<$\{artifactId.version\}>>> properties
+  and managed dependencies:
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
+---
+
+  This will automatically:
+
+  [[1]] Add <<<\<guava.version\>33.0.0-jre\</guava.version\>>>> to <<<\<properties\>>>>
+
+  [[2]] Add a managed dependency with <<<\<version\>$\{guava.version\}\</version\>>>> to <<<\<dependencyManagement\>>>>
+
+  [[3]] Add a version-less <<<\<dependency\>>>> entry to <<<\<dependencies\>>>>
+
+  []
+
+** Multi-module projects
+
+  In a multi-module project, when running from a child module that inherits managed dependencies
+  from a parent, the goal will:
+
+  * Detect that existing dependencies are version-less (managed by parent)
+
+  * Walk the parent POM chain to find the POM with <<<\<dependencyManagement\>>>>
+
+  * Scan the parent POM's managed dependencies for property naming patterns
+
+  * Add the version property and managed dependency to the parent POM
+
+  * Add a version-less dependency to the child POM
+
+  []
+
+---
+cd child-module
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
+---
+
+** Explicit overrides
+
+  You can override auto-detected conventions with explicit flags:
+
+  * <<<-Dmanaged=true>>> / <<<-Dmanaged=false>>>: Force or prevent using <<<\<dependencyManagement\>>>>
+
+  * <<<-DuseProperty=true>>> / <<<-DuseProperty=false>>>: Force or prevent using a version property
+
+  * <<<-DpropertyName=my.version>>>: Use a specific property name (implies <<<useProperty=true>>>)
+
+  * <<<-Dalign=false>>>: Disable convention detection entirely
+
+  []
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dalign=false -DpropertyName=guava.version
+---
+
+
+* Removing a dependency
+
+  The <<<dependency:remove>>> goal removes a dependency from the project's <<<pom.xml>>>.
+  Only <<<groupId>>> and <<<artifactId>>> are required.
+
+---
+mvn dependency:remove -Dgav=com.google.guava:guava
+---
+
+  To remove from <<<\<dependencyManagement\>>>> instead of <<<\<dependencies\>>>>:
+
+---
+mvn dependency:remove -Dgav=com.google.guava:guava -Dmanaged=true
+---
+
+  The goal fails with an error if the specified dependency is not found in the POM.
+
+
+* Searching for dependencies
+
+  The <<<dependency:search>>> goal searches Maven Central for artifacts. It does not require a project.
+
+---
+mvn dependency:search -Dquery=guava
+mvn dependency:search -Dquery="g:com.google.guava"
+mvn dependency:search -Dquery=guava -Drows=5
+---

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -34,6 +34,9 @@ ${project.name}
 
   The Dependency plugin has several goals:
 
+  *{{{./add-mojo.html}dependency:add}} adds or updates a dependency in the project's <<<pom.xml>>>, with optional
+  convention auto-detection for managed dependencies and version properties.
+
   *{{{./analyze-mojo.html}dependency:analyze}} analyzes the dependencies of this project and determines which are: used
   and declared; used and undeclared; unused and declared.
 
@@ -106,8 +109,12 @@ ${project.name}
   *{{{./unpack-dependencies-mojo.html}dependency:unpack-dependencies}} like
   copy-dependencies but unpacks.
 
+  *{{{./remove-mojo.html}dependency:remove}} removes a dependency from the project's <<<pom.xml>>>.
+
   *{{{./render-dependencies-mojo.html}dependency:render-dependencies}} like
   build-classpath but with a custom Velocity template.
+
+  *{{{./search-mojo.html}dependency:search}} searches Maven Central for artifacts matching a query string.
 
   []
 
@@ -156,6 +163,8 @@ ${project.name}
   * {{{./examples/tree-mojo.html}Tree Mojo}}
 
   * {{{./examples/render-dependencies.html}Render Dependencies}}
+
+  * {{{./examples/adding-removing-dependencies.html}Adding and Removing Dependencies}}
 
   []
 

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -714,3 +714,87 @@ mvn dependency:analyze-exclusions
 [WARNING]         - javax.annotation:javax.annotation-api
 [WARNING]         - javax.activation:javax.activation-api
 +---+
+
+
+* <<<dependency:add>>>
+
+  This goal adds or updates a dependency in the project's <<<pom.xml>>>. It uses lossless XML editing
+  (DomTrip) to preserve formatting, comments, and whitespace.
+
+  By default (<<<align=true>>>), the goal auto-detects the project's dependency management conventions
+  by analyzing existing dependencies. If the project uses <<<\<dependencyManagement\>>>>, the version is
+  added to the managed section (in the appropriate parent POM) and a version-less entry to
+  <<<\<dependencies\>>>>. If existing versions use property references (<<<$\{...\}>>>), a property is
+  created following the detected naming convention.
+
+  In its simplest form:
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre
+---
+
+  With an explicit scope:
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dscope=test
+---
+
+  Disabling convention alignment and explicitly requesting a managed dependency:
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dalign=false -Dmanaged=true
+---
+
+  Using an explicit version property name:
+
+---
+mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -DpropertyName=guava.version
+---
+
+  See {{{./examples/adding-removing-dependencies.html}Adding and Removing Dependencies}} for more
+  detailed examples including multi-module projects.
+
+
+* <<<dependency:remove>>>
+
+  This goal removes a dependency from the project's <<<pom.xml>>>. Like <<<dependency:add>>>, it uses
+  lossless XML editing to preserve formatting.
+
+---
+mvn dependency:remove -Dgav=com.google.guava:guava
+---
+
+  To remove from <<<\<dependencyManagement\>>>> instead of <<<\<dependencies\>>>>:
+
+---
+mvn dependency:remove -Dgav=com.google.guava:guava -Dmanaged=true
+---
+
+  The goal will fail with a <<<MojoFailureException>>> if the specified dependency is not found.
+
+
+* <<<dependency:search>>>
+
+  This goal searches Maven Central for artifacts matching a query string. It does not require a project
+  and can be run from any directory.
+
+---
+mvn dependency:search -Dquery=guava
+---
+
+  By default, up to 20 results are displayed. Use the <<<rows>>> parameter to change the limit:
+
+---
+mvn dependency:search -Dquery=guava -Drows=5
+---
+
+  Sample output:
+
++---+
+[INFO] Search results for: guava
+[INFO] ----------
+[INFO] GroupId                                   ArtifactId                     Version
+[INFO] com.google.guava                          guava                          33.0.0-jre
+[INFO] com.google.guava                          guava-testlib                  33.0.0-jre
+...
++---+

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -44,6 +44,7 @@ under the License.
       <item name="Purging local repository dependencies" href="examples/purging-local-repository.html"/>
       <item name="Dependency tree output formats" href="examples/tree-mojo.html"/>
       <item name="Render Dependencies" href="examples/render-dependencies.html"/>
+      <item name="Adding and Removing Dependencies" href="examples/adding-removing-dependencies.html"/>
     </menu>
     <menu name="Resources">
       <item name="Dependency Mechanism" href="../../guides/introduction/introduction-to-dependency-mechanism.html"/>


### PR DESCRIPTION
## Summary

Alternative approach to #1599 — thin mojos leveraging [DomTrip](https://github.com/maveniverse/domtrip) for lossless POM editing and `jakarta.json` for search API parsing.

- **`dependency:add`** — adds/updates a dependency, preserving formatting, comments, and whitespace. Supports `-Dgav`, `-Dmanaged`, `-Dscope`, `-DuseProperty`, `-DpropertyName`, `-Dalign`.
- **`dependency:remove`** — removes a dependency (regular or managed).
- **`dependency:search`** — searches Maven Central via the Sonatype Central Search API. Non-interactive tabular output.

### Convention auto-detection (`align=true`, the default)

When adding a dependency, the mojo analyzes existing dependencies to automatically follow the project's patterns:

- **Managed dependencies**: If most existing deps are version-less (delegated to `<dependencyManagement>`), the new dep is added the same way
- **Version properties**: If existing versions use property references (`${...}`), a property is created following the detected naming convention
- **Property naming**: Detects `.version` (e.g. `guava.version`), `-version` (e.g. `guava-version`, Camel-style), `Version` (camelCase), and `version.` prefix conventions
- **Multi-module**: Walks the parent POM chain to find the POM with `<dependencyManagement>`, adds the managed dep + property there, and adds a version-less dep to the child POM

Explicit flags (`-Dmanaged`, `-DuseProperty`, `-DpropertyName`, `-Dalign=false`) override auto-detected conventions.

### Usage examples

```bash
# Add a dependency (auto-detects conventions)
mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre

# Add with explicit scope
mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dscope=test

# Add with explicit managed dep and property
mvn dependency:add -Dgav=org.junit:junit-bom:5.11.0 -Dmanaged -DpropertyName=junit.version

# Disable convention detection
mvn dependency:add -Dgav=com.google.guava:guava:33.0.0-jre -Dalign=false

# Remove a dependency
mvn dependency:remove -Dgav=commons-io:commons-io

# Search Maven Central
mvn dependency:search -Dquery=guava -Drows=10
```

### Dependencies added

- `eu.maveniverse.maven.domtrip:domtrip-maven:0.6.0` (EPL-2.0, ASF Cat-B — already accepted in Maven 4 core)
- `org.glassfish:jakarta.json:2.0.1` promoted from test to compile scope (already in the project)

## Test plan

- [x] 13 integration tests covering all goals and convention detection scenarios
  - Basic add/remove, managed deps, properties, scopes
  - Multi-module with `.version` convention
  - Multi-module with `-version` convention (Camel-style)
  - Remove not-found (expected failure)
  - Search Maven Central
- [ ] CI build passes
- [ ] Manual testing in real projects (tested in Apache Camel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_