### PR TITLE
fix: log swallowed exceptions in module descriptor extraction

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/resolvers/ResolveDependenciesMojo.java
@@ -302,13 +302,13 @@ public class ResolveDependenciesMojo extends AbstractResolveMojo {
                                 moduleDescriptor.moduleNameSource = "FILENAME";
                             }
                         } catch (IOException e) {
-                            // noop
+                            getLog().debug("Failed to read manifest from " + artifactFile + ": " + e.getMessage());
                         }
                     }
                 }
             }
         } catch (ClassNotFoundException | SecurityException | IllegalAccessException | IllegalArgumentException e) {
-            // do nothing
+            getLog().debug("Failed to extract module descriptor using reflection: " + e.getMessage());
         } catch (NoSuchMethodException e) {
             getLog().warn(e);
         } catch (InvocationTargetException e) {


### PR DESCRIPTION
Replace silent catch blocks in `ResolveDependenciesMojo#getModuleDescriptor()`
  with `getLog().debug(...)` for IOException (manifest read) and reflection failures.

Fixes : #1614 

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
