### PR TITLE
Fix empty dependency exclusion filtering

### DIFF
--- a/src/it/projects/analyze/verify.groovy
+++ b/src/it/projects/analyze/verify.groovy
@@ -34,10 +34,12 @@ assert buildLog.contains( '[INFO]    org.apache.maven:maven-model:jar:2.0.6:comp
 assert buildLog.contains( '[WARNING] Used undeclared dependencies found:')
 assert buildLog.contains( '[WARNING]    org.apache.maven:maven-repository-metadata:jar:2.0.6:compile')
 assert buildLog.contains( '[WARNING]       class org.apache.maven.artifact.repository.metadata.Metadata')
+assert !buildLog.contains( '[INFO] Ignored used undeclared dependencies:')
 assert buildLog.contains( '[WARNING] Unused declared dependencies found:')
 assert buildLog.contains( '[WARNING]    org.apache.maven:maven-project:jar:2.0.6:compile')
 assert buildLog.contains( '[INFO] Ignored unused declared dependencies:')
 assert buildLog.contains( '[INFO]    org.slf4j:slf4j-simple:jar:2.0.16:compile')
+assert !buildLog.contains( '[INFO]    org.apache.maven:maven-project:jar:2.0.6:compile')
 assert !buildLog.contains( '[WARNING]    org.slf4j:slf4j-simple:jar:2.0.16:compile')
 
 return true

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -21,6 +21,7 @@ package org.apache.maven.plugins.dependency.analyze;
 import java.io.File;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -560,7 +561,7 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
 
     private Set<Artifact> filterDependencies(Set<Artifact> artifacts, String[] excludes) {
         if (excludes == null || excludes.length == 0) {
-            return artifacts;
+            return Collections.emptySet();
         }
         ArtifactFilter filter = new StrictPatternExcludesArtifactFilter(Arrays.asList(excludes));
         Set<Artifact> result = new LinkedHashSet<>();


### PR DESCRIPTION
## Summary

- return an empty result when dependency exclusion patterns are absent
- stop verbose analysis output from reporting real findings again as ignored dependencies
- add integration assertions for both used-undeclared and unused-declared output

Fixes #1645.

## Root cause

`filterDependencies(...)` returned its full input set when the exclusion array was null or empty. Callers treat the return value as the dependencies removed by an exclusion filter, so the full input was incorrectly added to the ignored-dependency sections.

## Verification

- regression assertions failed before the production change and passed afterward
- `mvn -Prun-its -Dinvoker.test=analyze verify` — passed
- `mvn -Prun-its verify` — passed; 99 integration projects, 0 failures or errors
- unit tests, Checkstyle, Spotless, Apache RAT, compilation, and packaging passed as part of the full build
- `git diff --check` — passed
