### PR TITLE
writeScriptableOutput appends empty string for null classifier

### DIFF
--- a/src/it/projects/mdep-1650-scriptable-output-null-classifier/invoker.properties
+++ b/src/it/projects/mdep-1650-scriptable-output-null-classifier/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean ${project.groupId}:${project.artifactId}:${project.version}:analyze

--- a/src/it/projects/mdep-1650-scriptable-output-null-classifier/pom.xml
+++ b/src/it/projects/mdep-1650-scriptable-output-null-classifier/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>mdep-1650</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test</name>
+  <description>
+    Test dependency:analyze scriptableOutput does not append literal "null" for null classifier
+  </description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.0.6</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <verbose>true</verbose>
+            <scriptableOutput>true</scriptableOutput>
+            <scriptableFlag>TESTFLAG</scriptableFlag>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/src/it/projects/mdep-1650-scriptable-output-null-classifier/src/main/java/test/App.java
+++ b/src/it/projects/mdep-1650-scriptable-output-null-classifier/src/main/java/test/App.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test;
+import org.apache.maven.model.Model;
+public class App {
+    public Model model = null;
+}

--- a/src/it/projects/mdep-1650-scriptable-output-null-classifier/verify.groovy
+++ b/src/it/projects/mdep-1650-scriptable-output-null-classifier/verify.groovy
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+File buildLog = new File( basedir, "build.log" )
+assert buildLog.exists()
+
+String log = buildLog.getText( "UTF-8" )
+
+// verify scriptable output is present
+assert log.contains( 'Missing dependencies:' )
+assert log.contains( 'TESTFLAG:' )
+
+// verify no scriptable output line contains ":null:" (null classifier)
+log.eachLine { line ->
+    if ( line.contains( 'TESTFLAG:' ) ) {
+        assert !line.contains( ':null:' )
+    }
+}
+
+return true

--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AbstractAnalyzeMojo.java
@@ -547,7 +547,7 @@ public abstract class AbstractAnalyzeMojo extends AbstractMojo {
                         .append(":")
                         .append(artifact.getDependencyConflictId())
                         .append(":")
-                        .append(artifact.getClassifier())
+                        .append(artifact.getClassifier() != null ? artifact.getClassifier() : "")
                         .append(":")
                         .append(artifact.getBaseVersion())
                         .append(":")


### PR DESCRIPTION
## Summary

`writeScriptableOutput()` appends the literal string `"null"` for dependencies without a classifier, producing `...:null:...` instead of `...::...`.

fixes #1650

## Root cause

Line 550 in `AbstractAnalyzeMojo.java`:

```java
.append(artifact.getClassifier())
```

`artifact.getClassifier()` returns `null` when no classifier is set, and `StringBuilder.append(null)` appends the literal string `"null"`.

## Fix

```java
.append(artifact.getClassifier() != null ? artifact.getClassifier() : "")
```

Note that `writeDependencyXML()` (line 516) already handles null classifier correctly with an explicit null check.

## Integration test

Added `mdep-1650-scriptable-output-null-classifier` IT that:
- Declares `maven-project`, uses `maven-model` (transitive)
- Configures `scriptableOutput=true` with a known flag value
- Asserts that no `TESTFLAG:` line contains `:null:`

The test fails at HEAD and passes with the fix.