### PR TITLE
throw MojoExecutionException when artifact has no file in PropertiesMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/PropertiesMojo.java
@@ -20,6 +20,7 @@ package org.apache.maven.plugins.dependency;
 
 import javax.inject.Inject;
 
+import java.io.File;
 import java.util.List;
 import java.util.Set;
 
@@ -112,10 +113,12 @@ public class PropertiesMojo extends AbstractMojo {
         Set<Artifact> artifacts = project.getArtifacts();
 
         for (Artifact artifact : artifacts) {
-            project.getProperties()
-                    .setProperty(
-                            artifact.getDependencyConflictId(),
-                            artifact.getFile().getAbsolutePath());
+            File file = artifact.getFile();
+            if (file == null) {
+                throw new MojoExecutionException("Could not resolve artifact " + artifact.getDependencyConflictId()
+                        + " to a file; the dependency:properties goal requires a resolved artifact.");
+            }
+            project.getProperties().setProperty(artifact.getDependencyConflictId(), file.getAbsolutePath());
         }
 
         if (extraArtifacts != null) {
@@ -130,10 +133,12 @@ public class PropertiesMojo extends AbstractMojo {
                             resolverUtil.createArtifactFromParams(paramArtifact);
                     artifact = resolverUtil.resolveArtifact(artifact, project.getRemoteProjectRepositories());
 
-                    this.project
-                            .getProperties()
-                            .setProperty(
-                                    toConflictId(artifact), artifact.getFile().getAbsolutePath());
+                    File file = artifact.getFile();
+                    if (file == null) {
+                        throw new MojoExecutionException("Could not resolve extra artifact " + toConflictId(artifact)
+                                + " to a file; the dependency:properties goal requires a resolved artifact.");
+                    }
+                    this.project.getProperties().setProperty(toConflictId(artifact), file.getAbsolutePath());
                 }
             } catch (ArtifactResolutionException | ArtifactDescriptorException e) {
                 throw new MojoExecutionException("Couldn't download artifact: " + e.getMessage(), e);


### PR DESCRIPTION
`PropertiesMojo` sets project properties to artifact file paths. `artifact.getFile()` can return `null` for unresolved or POM-packaged artifacts. `Properties.setProperty()` throws NPE on null values, so calling `artifact.getFile().getAbsolutePath()` with a null file crashes the build with an unhelpful stack trace.

fixes #1647

Instead, throw `MojoExecutionException` with a clear diagnostic message at both potential NPE sites:
- `project.getArtifacts()` loop (line 118)
- `extraArtifacts` resolution path (line 136)