### PR TITLE
Add AGENTS.md + SECURITY.md security-model pointer for scanner discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Agent Guide for maven-dependency-plugin
+
+This file is read by automated agents (security scanners, code
+analyzers, AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+
+Agents that scan this repository should consult `SECURITY.md` and the
+threat model it links before reporting issues.
+
+Points at the Apache Maven family umbrella security model.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+`apache/maven-dependency-plugin` follows the [Apache Software Foundation security process](https://www.apache.org/security/). Please report suspected
+vulnerabilities privately to `security@apache.org`; do not open public
+GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+What the project treats as in scope and out of scope, the security
+properties it provides and disclaims, the adversary model, and how
+findings are triaged are documented in <https://github.com/apache/maven/blob/master/THREAT_MODEL.md>.


### PR DESCRIPTION
**This is a proposal for the PMC to review — please correct, reject, or discuss as needed.** Nothing here is a requirement; the maintainer is the decision-maker.

This adds a small `AGENTS.md` + `SECURITY.md` so an automated scan agent can mechanically discover the project's security model via the conventional `AGENTS.md → SECURITY.md` chain. It points at the Maven family's umbrella threat model, which the PMC merged in `apache/maven` (`THREAT_MODEL.md`) — no model content is duplicated here, just the pointer.

Context: the ASF Security team is preparing the Maven repositories for an automated agentic security scan we're piloting. Such scans refuse to run if the model isn't discoverable by that path. Discoverability is the one hard gate; everything else is suggestion.

Doc-only; questions / pushback welcome.
