### PR TITLE
Fix copy and unpack for artifacts with unavailable parents

### DIFF
--- a/src/it/mrm/repository/broken-parent-artifact-1.0.pom
+++ b/src/it/mrm/repository/broken-parent-artifact-1.0.pom
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.its.dependency</groupId>
+    <artifactId>missing-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>broken-parent-artifact</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+</project>

--- a/src/it/projects/copy-broken-parent/invoker.properties
+++ b/src/it/projects/copy-broken-parent/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources

--- a/src/it/projects/copy-broken-parent/pom.xml
+++ b/src/it/projects/copy-broken-parent/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>copy-broken-parent</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.maven.its.dependency</groupId>
+                  <artifactId>broken-parent-artifact</artifactId>
+                  <version>1.0</version>
+                  <type>pom</type>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/projects/copy-broken-parent/verify.groovy
+++ b/src/it/projects/copy-broken-parent/verify.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/dependency/broken-parent-artifact-1.0.pom').isFile()

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -46,7 +46,6 @@ import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.LocalRepository;
 import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.eclipse.aether.resolution.ArtifactDescriptorException;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -256,11 +255,11 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
 
             RepositorySystemSession repositorySession = createSystemSessionForLocalRepo();
 
-            org.eclipse.aether.artifact.Artifact resolvedArtifact = resolverUtil.resolveArtifact(
+            org.eclipse.aether.artifact.Artifact resolvedArtifact = resolverUtil.resolveArtifactWithFallback(
                     artifact, getProject().getRemoteProjectRepositories(), repositorySession);
             return RepositoryUtils.toArtifact(resolvedArtifact);
 
-        } catch (ArtifactResolutionException | ArtifactDescriptorException e) {
+        } catch (ArtifactResolutionException e) {
             throw new MojoExecutionException("Unable to find/resolve artifact.", e);
         }
     }

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
@@ -133,9 +133,37 @@ public class ResolverUtil {
         ArtifactDescriptorResult artifactDescriptorResult = repositorySystem.readArtifactDescriptor(
                 session, new ArtifactDescriptorRequest(artifact, repositories, null));
 
-        Artifact artifactToResolve = artifactDescriptorResult.getArtifact();
+        return resolveArtifactDirectly(artifactDescriptorResult.getArtifact(), repositories, session);
+    }
 
-        ArtifactRequest request = new ArtifactRequest(artifactToResolve, repositories, null);
+    /**
+     * Resolve a given artifact, falling back to its original coordinates when its descriptor cannot be read.
+     *
+     * @param artifact     an artifact to resolve
+     * @param repositories remote repositories list
+     * @param session      a repository system session
+     * @return resolved artifact
+     * @throws ArtifactResolutionException if the artifact could not be resolved
+     */
+    public Artifact resolveArtifactWithFallback(
+            Artifact artifact, List<RemoteRepository> repositories, RepositorySystemSession session)
+            throws ArtifactResolutionException {
+        try {
+            return resolveArtifact(artifact, repositories, session);
+        } catch (ArtifactDescriptorException descriptorException) {
+            try {
+                return resolveArtifactDirectly(artifact, repositories, session);
+            } catch (ArtifactResolutionException resolutionException) {
+                resolutionException.addSuppressed(descriptorException);
+                throw resolutionException;
+            }
+        }
+    }
+
+    private Artifact resolveArtifactDirectly(
+            Artifact artifact, List<RemoteRepository> repositories, RepositorySystemSession session)
+            throws ArtifactResolutionException {
+        ArtifactRequest request = new ArtifactRequest(artifact, repositories, null);
         ArtifactResult result = repositorySystem.resolveArtifact(session, request);
         return result.getArtifact();
     }

--- a/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
@@ -20,13 +20,22 @@ package org.apache.maven.plugins.dependency.utils;
 
 import javax.inject.Provider;
 
+import java.util.Collections;
 import java.util.stream.Stream;
 
 import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactDescriptorRequest;
+import org.eclipse.aether.resolution.ArtifactDescriptorResult;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -39,6 +48,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.junit.jupiter.params.provider.Arguments.of;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,6 +67,9 @@ class ResolverUtilTest {
 
     @Mock
     private Provider<MavenSession> sessionProvider;
+
+    @Mock
+    private RepositorySystem repositorySystem;
 
     @InjectMocks
     private ResolverUtil resolverUtil;
@@ -104,5 +119,23 @@ class ResolverUtilTest {
         assertThatCode(() -> resolverUtil.prepareRemoteRepository(null))
                 .isExactlyInstanceOf(NullPointerException.class)
                 .hasMessage("repository must be not null");
+    }
+
+    @Test
+    void resolveArtifactWithFallbackWhenDescriptorCannotBeRead() throws Exception {
+        Artifact artifact = new DefaultArtifact("groupId", "artifactId", null, "jar", "1.0");
+        ArtifactDescriptorRequest descriptorRequest = new ArtifactDescriptorRequest();
+        ArtifactDescriptorException descriptorException =
+                new ArtifactDescriptorException(new ArtifactDescriptorResult(descriptorRequest));
+        ArtifactResult artifactResult = new ArtifactResult(new ArtifactRequest()).setArtifact(artifact);
+
+        when(repositorySystem.readArtifactDescriptor(eq(repositorySystemSession), any(ArtifactDescriptorRequest.class)))
+                .thenThrow(descriptorException);
+        when(repositorySystem.resolveArtifact(eq(repositorySystemSession), any(ArtifactRequest.class)))
+                .thenReturn(artifactResult);
+
+        assertThat(resolverUtil.resolveArtifactWithFallback(artifact, Collections.emptyList(), repositorySystemSession))
+                .isSameAs(artifact);
+        verify(repositorySystem).resolveArtifact(eq(repositorySystemSession), any(ArtifactRequest.class));
     }
 }

--- a/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
@@ -136,6 +136,8 @@ class ResolverUtilTest {
 
         assertThat(resolverUtil.resolveArtifactWithFallback(artifact, Collections.emptyList(), repositorySystemSession))
                 .isSameAs(artifact);
-        verify(repositorySystem).readArtifactDescriptor(eq(repositorySystemSession), any(ArtifactDescriptorRequest.class));
+        verify(repositorySystem)
+                .readArtifactDescriptor(eq(repositorySystemSession), any(ArtifactDescriptorRequest.class));
         verify(repositorySystem).resolveArtifact(eq(repositorySystemSession), any(ArtifactRequest.class));
+    }
 }

--- a/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
@@ -136,6 +136,6 @@ class ResolverUtilTest {
 
         assertThat(resolverUtil.resolveArtifactWithFallback(artifact, Collections.emptyList(), repositorySystemSession))
                 .isSameAs(artifact);
+        verify(repositorySystem).readArtifactDescriptor(eq(repositorySystemSession), any(ArtifactDescriptorRequest.class));
         verify(repositorySystem).resolveArtifact(eq(repositorySystemSession), any(ArtifactRequest.class));
-    }
 }


### PR DESCRIPTION
Maven Dependency Plugin 3.11.0 made artifact descriptor resolution mandatory for `copy` and `unpack`, which prevents otherwise available artifacts from being processed when their POM references an unavailable snapshot parent.

This change preserves descriptor-based relocation support, but scopes a fallback to the from-configuration goals: when descriptor reading fails, the original artifact coordinates are resolved directly. Artifact resolution failures still fail the goal and retain the descriptor exception as suppressed context.

A repository-backed integration test reproduces the unavailable snapshot-parent case, and focused resolver coverage verifies the fallback. Existing copy and unpack relocation integration tests continue to pass.

Fixes: #1642