### PR TITLE
Remove unreachable null check from BuildClasspathMojo

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/BuildClasspathMojo.java
@@ -198,7 +198,7 @@ public class BuildClasspathMojo extends AbstractDependencyFilterMojo implements 
 
         Set<Artifact> artifacts = getResolvedDependencies(true);
 
-        if (artifacts == null || artifacts.isEmpty()) {
+        if (artifacts.isEmpty()) {
             getLog().info("No dependencies found.");
         }
 


### PR DESCRIPTION
`getResolvedDependencies(true)` supplies a non-null `Set`; projects with no resolved dependencies receive an empty set. Remove the misleading `artifacts == null` condition from `BuildClasspathMojo` while retaining the existing empty-set logging and empty classpath output.

This aligns the Mojo with the dependency resolver's effective contract. Because the null case cannot be produced through the supported Maven dependency-resolution path, no defensive conversion or null-specific test is needed.

Fixes #1648.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
  This is not a behavioral change: the null branch is unreachable, and the existing empty-set behavior is unchanged.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
