### PR TITLE
[MDEP-726] Resolve artifact item versions from transitive dependencies

### DIFF
--- a/src/it/mrm/repository/copy-transitive-root-1.0.pom
+++ b/src/it/mrm/repository/copy-transitive-root-1.0.pom
@@ -20,52 +20,18 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
-  <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:copy with relocation
-  </description>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+  <artifactId>copy-transitive-root</artifactId>
+  <version>1.0</version>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>ResourceArtifact</artifactId>
       <version>1.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>@project.version@</version>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/mrm/repository/provided-root-1.0.pom
+++ b/src/it/mrm/repository/provided-root-1.0.pom
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,58 +17,18 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
-  <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
+  <artifactId>provided-root</artifactId>
+  <version>1.0</version>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>scope-leaf</artifactId>
       <version>1.0</version>
     </dependency>
   </dependencies>
-  
-  <build>
-
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>@project.version@</version>
-        <executions>
-          <execution>
-            <id>unpack</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/mrm/repository/scope-leaf-1.0.pom
+++ b/src/it/mrm/repository/scope-leaf-1.0.pom
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>scope-leaf</artifactId>
+  <version>1.0</version>
+</project>

--- a/src/it/mrm/repository/scope-leaf-2.0.pom
+++ b/src/it/mrm/repository/scope-leaf-2.0.pom
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.maven.its.dependency</groupId>
+  <artifactId>scope-leaf</artifactId>
+  <version>2.0</version>
+</project>

--- a/src/it/mrm/repository/scope-root-1.0.pom
+++ b/src/it/mrm/repository/scope-root-1.0.pom
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,58 +17,18 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
-  <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
+  <artifactId>scope-root</artifactId>
+  <version>1.0</version>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>scope-leaf</artifactId>
       <version>1.0</version>
     </dependency>
   </dependencies>
-  
-  <build>
-
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>@project.version@</version>
-        <executions>
-          <execution>
-            <id>unpack</id>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/mrm/repository/scope-test-root-1.0.pom
+++ b/src/it/mrm/repository/scope-test-root-1.0.pom
@@ -17,55 +17,18 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
-  <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:copy with relocation
-  </description>
-
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
+  <artifactId>scope-test-root</artifactId>
+  <version>1.0</version>
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
-      <version>1.0</version>
+      <artifactId>scope-leaf</artifactId>
+      <version>2.0</version>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>@project.version@</version>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>copy</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/src/it/projects/copy-relocation-without-version/invoker.properties
+++ b/src/it/projects/copy-relocation-without-version/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources

--- a/src/it/projects/copy-relocation-without-version/pom.xml
+++ b/src/it/projects/copy-relocation-without-version/pom.xml
@@ -24,17 +24,25 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <artifactId>copy-relocation-without-version</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <name>Test</name>
   <description>
-    Test dependency:copy with relocation
+    Test dependency:copy with relocation and a version resolved from the project dependencies
   </description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.dependency</groupId>
+      <artifactId>ResourceArtifact-relocation</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
 
   <build>
     <plugins>
@@ -52,7 +60,6 @@
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
                   <artifactId>ResourceArtifact-relocation</artifactId>
-                  <version>1.0</version>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/copy-relocation-without-version/verify.groovy
+++ b/src/it/projects/copy-relocation-without-version/verify.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/dependency/ResourceArtifact-1.0.jar').isFile()

--- a/src/it/projects/mdep-726-copy-transitive-version/invoker.properties
+++ b/src/it/projects/mdep-726-copy-transitive-version/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources

--- a/src/it/projects/mdep-726-copy-transitive-version/pom.xml
+++ b/src/it/projects/mdep-726-copy-transitive-version/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,52 +17,59 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
+
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
-  <version>1.0-SNAPSHOT</version>
 
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>mdep-726-copy-transitive-version</artifactId>
+  <version>1.0-SNAPSHOT</version>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>copy-transitive-root</artifactId>
       <version>1.0</version>
     </dependency>
   </dependencies>
-  
-  <build>
 
+  <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>unpack</id>
+            <id>copy-transitive-artifact</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>copy</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.apache.maven.its.dependency</groupId>
+                  <artifactId>ResourceArtifact</artifactId>
+                  <outputDirectory>${project.build.directory}/copied</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-transitive-artifact</id>
+            <phase>process-sources</phase>
             <goals>
               <goal>unpack</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
+                  <artifactId>ResourceArtifact</artifactId>
+                  <outputDirectory>${project.build.directory}/unpacked</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/mdep-726-copy-transitive-version/verify.groovy
+++ b/src/it/projects/mdep-726-copy-transitive-version/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/copied/ResourceArtifact-1.0.jar').isFile()
+assert new File(basedir, 'target/unpacked/resource1.txt').isFile()

--- a/src/it/projects/mdep-726-managed-version-before-graph/invoker.properties
+++ b/src/it/projects/mdep-726-managed-version-before-graph/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources

--- a/src/it/projects/mdep-726-managed-version-before-graph/pom.xml
+++ b/src/it/projects/mdep-726-managed-version-before-graph/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,52 +17,50 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>mdep-726-managed-version-before-graph</artifactId>
   <version>1.0-SNAPSHOT</version>
 
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.maven.its.dependency</groupId>
+        <artifactId>ResourceArtifact</artifactId>
+        <version>1.0</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
-      <version>1.0</version>
+      <groupId>review.missing</groupId>
+      <artifactId>unrelated</artifactId>
+      <version>[1.0,2.0)</version>
     </dependency>
   </dependencies>
-  
-  <build>
 
+  <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>unpack</id>
+            <id>copy-managed-artifact</id>
+            <phase>process-sources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>copy</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
+                  <artifactId>ResourceArtifact</artifactId>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/mdep-726-managed-version-before-graph/verify.groovy
+++ b/src/it/projects/mdep-726-managed-version-before-graph/verify.groovy
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/dependency/ResourceArtifact-1.0.jar').isFile()

--- a/src/it/projects/mdep-726-scope-ambiguity/invoker.properties
+++ b/src/it/projects/mdep-726-scope-ambiguity/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals = clean process-sources
+invoker.buildResult = failure

--- a/src/it/projects/mdep-726-scope-ambiguity/pom.xml
+++ b/src/it/projects/mdep-726-scope-ambiguity/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,52 +17,45 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>mdep-726-scope-ambiguity</artifactId>
   <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>scope-test-root</artifactId>
       <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.its.dependency</groupId>
+      <artifactId>provided-root</artifactId>
+      <version>1.0</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
-  
   <build>
-
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>unpack</id>
+            <id>ambiguous-version</id>
+            <phase>process-sources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>copy</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
+                  <artifactId>scope-leaf</artifactId>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/mdep-726-scope-ambiguity/verify.groovy
+++ b/src/it/projects/mdep-726-scope-ambiguity/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def log = new File(basedir, 'build.log').text
+assert log.contains('Dependency graphs select different versions of org.apache.maven.its.dependency:scope-leaf')
+assert log.contains('compile=1.0')
+assert log.contains('test=2.0')

--- a/src/it/projects/mdep-726-scope-selection/invoker.properties
+++ b/src/it/projects/mdep-726-scope-selection/invoker.properties
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+invoker.goals = clean process-sources

--- a/src/it/projects/mdep-726-scope-selection/pom.xml
+++ b/src/it/projects/mdep-726-scope-selection/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -18,52 +17,66 @@
   ~ specific language governing permissions and limitations
   ~ under the License.
   -->
-  
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
-  <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>mdep-726-scope-selection</artifactId>
   <version>1.0-SNAPSHOT</version>
-
-  <name>Test</name>
-  <description>
-    Test dependency:unpack with relocation
-  </description>
-  
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
+      <artifactId>scope-test-root</artifactId>
+      <version>1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.its.dependency</groupId>
+      <artifactId>scope-root</artifactId>
       <version>1.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.its.dependency</groupId>
+      <artifactId>provided-root</artifactId>
+      <version>1.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
-  
-  <build>
 
+  <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>unpack</id>
+            <id>copy-scope-selected-versions</id>
+            <phase>process-sources</phase>
             <goals>
-              <goal>unpack</goal>
+              <goal>copy</goal>
             </goals>
             <configuration>
-              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
-                  <artifactId>ResourceArtifact-relocation</artifactId>
+                  <artifactId>scope-leaf</artifactId>
+                  <dependencyScope>compile</dependencyScope>
+                  <outputDirectory>${project.build.directory}/compile</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.maven.its.dependency</groupId>
+                  <artifactId>scope-leaf</artifactId>
+                  <dependencyScope>runtime</dependencyScope>
+                  <outputDirectory>${project.build.directory}/runtime</outputDirectory>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.apache.maven.its.dependency</groupId>
+                  <artifactId>scope-leaf</artifactId>
+                  <dependencyScope>test</dependencyScope>
+                  <outputDirectory>${project.build.directory}/test</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/mdep-726-scope-selection/verify.groovy
+++ b/src/it/projects/mdep-726-scope-selection/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/compile/scope-leaf-1.0.jar').isFile()
+assert new File(basedir, 'target/runtime/scope-leaf-1.0.jar').isFile()
+assert new File(basedir, 'target/test/scope-leaf-2.0.jar').isFile()

--- a/src/it/projects/unpack-relocation-without-version/invoker.properties
+++ b/src/it/projects/unpack-relocation-without-version/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean process-sources

--- a/src/it/projects/unpack-relocation-without-version/pom.xml
+++ b/src/it/projects/unpack-relocation-without-version/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ Licensed to the Apache Software Foundation (ASF) under one
   ~ or more contributor license agreements.  See the NOTICE file
@@ -21,38 +22,48 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.apache.maven.its.dependency</groupId>
-  <artifactId>test</artifactId>
+  <artifactId>unpack-relocation-without-version</artifactId>
   <version>1.0-SNAPSHOT</version>
 
   <name>Test</name>
   <description>
-    Test dependency:copy with relocation
+    Test dependency:unpack with relocation and a version resolved from the project dependencies
   </description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.its.dependency</groupId>
+      <artifactId>ResourceArtifact-relocation</artifactId>
+      <version>1.0</version>
+    </dependency>
+  </dependencies>
+
   <build>
+
     <plugins>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
           <execution>
-            <id>test</id>
+            <id>unpack</id>
             <goals>
-              <goal>copy</goal>
+              <goal>unpack</goal>
             </goals>
             <configuration>
+              <outputDirectory>${project.build.directory}/ResourceArtifact</outputDirectory>
               <artifactItems>
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
                   <artifactId>ResourceArtifact-relocation</artifactId>
-                  <version>1.0</version>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/it/projects/unpack-relocation-without-version/verify.groovy
+++ b/src/it/projects/unpack-relocation-without-version/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+assert new File(basedir, 'target/ResourceArtifact/META-INF/MANIFEST.MF').isFile()
+assert new File(basedir, 'target/ResourceArtifact/resource1.txt').isFile()
+assert new File(basedir, 'target/ResourceArtifact/resource2.txt').isFile()

--- a/src/it/projects/unpack-relocation/pom.xml
+++ b/src/it/projects/unpack-relocation/pom.xml
@@ -37,14 +37,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.maven.its.dependency</groupId>
-      <artifactId>ResourceArtifact-relocation</artifactId>
-      <version>1.0</version>
-    </dependency>
-  </dependencies>
   
   <build>
 
@@ -64,6 +56,7 @@
                 <artifactItem>
                   <groupId>org.apache.maven.its.dependency</groupId>
                   <artifactId>ResourceArtifact-relocation</artifactId>
+                  <version>1.0</version>
                 </artifactItem>
               </artifactItems>
             </configuration>

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -129,8 +129,8 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
         super(session, buildContext, project);
         this.artifactHandlerManager = artifactHandlerManager;
         this.resolverUtil = resolverUtil;
-        this.dependencyVersionResolver =
-                new DependencyVersionResolver(session, project, new DefaultDependencyCollectorBuilder(repositorySystem));
+        this.dependencyVersionResolver = new DependencyVersionResolver(
+                session, project, new DefaultDependencyCollectorBuilder(repositorySystem));
     }
 
     abstract ArtifactItemFilter getMarkedArtifactFilter(ArtifactItem item);

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -37,7 +37,8 @@ import org.apache.maven.plugins.dependency.utils.ResolverUtil;
 import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
-import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
+import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyCollectorBuilder;
+import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
@@ -123,12 +124,13 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
             BuildContext buildContext,
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
-            ResolverUtil resolverUtil,
-            DependencyCollectorBuilder dependencyCollectorBuilder) {
+            RepositorySystem repositorySystem,
+            ResolverUtil resolverUtil) {
         super(session, buildContext, project);
         this.artifactHandlerManager = artifactHandlerManager;
         this.resolverUtil = resolverUtil;
-        this.dependencyVersionResolver = new DependencyVersionResolver(session, project, dependencyCollectorBuilder);
+        this.dependencyVersionResolver =
+                new DependencyVersionResolver(session, project, new DefaultDependencyCollectorBuilder(repositorySystem));
     }
 
     abstract ArtifactItemFilter getMarkedArtifactFilter(ArtifactItem item);

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/AbstractFromConfigurationMojo.java
@@ -21,7 +21,6 @@ package org.apache.maven.plugins.dependency.fromConfiguration;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.RepositoryUtils;
@@ -29,7 +28,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -39,13 +37,9 @@ import org.apache.maven.plugins.dependency.utils.ResolverUtil;
 import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.artifact.filter.collection.ArtifactFilterException;
-import org.eclipse.aether.DefaultRepositoryCache;
-import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.eclipse.aether.RepositorySystem;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.repository.LocalRepository;
-import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.eclipse.aether.resolution.ArtifactResolutionException;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
@@ -100,8 +94,9 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
     private boolean overWriteIfNewer;
 
     /**
-     * Collection of ArtifactItems to work on. (ArtifactItem contains groupId, artifactId, version, type, classifier,
-     * outputDirectory, destFileName, overWrite and encoding.) See <a href="./usage.html">Usage</a> for details.
+     * Collection of ArtifactItems to work on. (ArtifactItem contains groupId, artifactId, version, dependencyScope,
+     * type, classifier, outputDirectory, destFileName, overWrite and encoding.) See <a href="./usage.html">Usage</a>
+     * for details.
      *
      * @since 1.0
      */
@@ -119,21 +114,21 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
 
     private final ArtifactHandlerManager artifactHandlerManager;
 
-    private final RepositorySystem repositorySystem;
-
     private final ResolverUtil resolverUtil;
+
+    private final DependencyVersionResolver dependencyVersionResolver;
 
     protected AbstractFromConfigurationMojo(
             MavenSession session,
             BuildContext buildContext,
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
-            RepositorySystem repositorySystem,
-            ResolverUtil resolverUtil) {
+            ResolverUtil resolverUtil,
+            DependencyCollectorBuilder dependencyCollectorBuilder) {
         super(session, buildContext, project);
         this.artifactHandlerManager = artifactHandlerManager;
-        this.repositorySystem = repositorySystem;
         this.resolverUtil = resolverUtil;
+        this.dependencyVersionResolver = new DependencyVersionResolver(session, project, dependencyCollectorBuilder);
     }
 
     abstract ArtifactItemFilter getMarkedArtifactFilter(ArtifactItem item);
@@ -207,22 +202,15 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
     }
 
     private RepositorySystemSession createSystemSessionForLocalRepo() {
-        RepositorySystemSession repositorySystemSession = session.getRepositorySession();
+        RepositorySystemSession repositorySystemSession =
+                resolverUtil.repositorySystemSession(localRepositoryDirectory);
         if (localRepositoryDirectory != null) {
-            // "clone" repository session and replace localRepository
-            DefaultRepositorySystemSession newSession =
-                    new DefaultRepositorySystemSession(session.getRepositorySession());
-            // Clear cache, since we're using a new local repository
-            newSession.setCache(new DefaultRepositoryCache());
-            LocalRepositoryManager localRepositoryManager = repositorySystem.newLocalRepositoryManager(
-                    newSession, new LocalRepository(localRepositoryDirectory));
-
-            newSession.setLocalRepositoryManager(localRepositoryManager);
-            repositorySystemSession = newSession;
             getLog().debug("localRepoPath: "
-                    + localRepositoryManager.getRepository().getBasedir());
+                    + repositorySystemSession
+                            .getLocalRepositoryManager()
+                            .getRepository()
+                            .getBasedir());
         }
-
         return repositorySystemSession;
     }
 
@@ -273,43 +261,7 @@ public abstract class AbstractFromConfigurationMojo extends AbstractDependencyMo
      * @throws MojoExecutionException
      */
     private void fillMissingArtifactVersion(ArtifactItem artifact) throws MojoExecutionException {
-        MavenProject project = getProject();
-        List<Dependency> deps = project.getDependencies();
-        List<Dependency> depMngt = project.getDependencyManagement() == null
-                ? Collections.emptyList()
-                : project.getDependencyManagement().getDependencies();
-
-        if (!findDependencyVersion(artifact, deps, false)
-                && (project.getDependencyManagement() == null || !findDependencyVersion(artifact, depMngt, false))
-                && !findDependencyVersion(artifact, deps, true)
-                && (project.getDependencyManagement() == null || !findDependencyVersion(artifact, depMngt, true))) {
-            throw new MojoExecutionException("Unable to find artifact version of " + artifact.getGroupId() + ":"
-                    + artifact.getArtifactId() + " in either dependency list or in project's dependency management.");
-        }
-    }
-
-    /**
-     * Tries to find missing version from a list of dependencies. If found, the artifact is updated with the correct
-     * version.
-     *
-     * @param artifact representing configured file
-     * @param dependencies list of dependencies to search
-     * @param looseMatch only look at artifactId and groupId
-     * @return the found dependency
-     */
-    private boolean findDependencyVersion(ArtifactItem artifact, List<Dependency> dependencies, boolean looseMatch) {
-        for (Dependency dependency : dependencies) {
-            if (Objects.equals(dependency.getArtifactId(), artifact.getArtifactId())
-                    && Objects.equals(dependency.getGroupId(), artifact.getGroupId())
-                    && (looseMatch || Objects.equals(dependency.getClassifier(), artifact.getClassifier()))
-                    && (looseMatch || Objects.equals(dependency.getType(), artifact.getType()))) {
-                artifact.setVersion(dependency.getVersion());
-
-                return true;
-            }
-        }
-
-        return false;
+        artifact.setVersion(dependencyVersionResolver.resolveVersion(artifact));
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ArtifactItem.java
@@ -53,6 +53,16 @@ public class ArtifactItem {
     private String version = null;
 
     /**
+     * Classpath scope from which to infer a missing version when the artifact is not found in direct dependencies or
+     * dependency management. Supported values are {@code compile}, {@code runtime}, and {@code test}. When omitted,
+     * all three dependency graphs are considered and must agree on the selected version.
+     *
+     * @since 3.11.1
+     */
+    @Parameter
+    private String dependencyScope;
+
+    /**
      * Type of artifact (War, Jar, etc.)
      */
     @Parameter(required = true)
@@ -192,6 +202,22 @@ public class ArtifactItem {
      */
     public void setVersion(String version) {
         this.version = filterEmptyString(version);
+    }
+
+    /**
+     * @return classpath scope used to infer a missing version
+     * @since 3.11.1
+     */
+    public String getDependencyScope() {
+        return dependencyScope;
+    }
+
+    /**
+     * @param dependencyScope classpath scope used to infer a missing version
+     * @since 3.11.1
+     */
+    public void setDependencyScope(String dependencyScope) {
+        this.dependencyScope = filterEmptyString(dependencyScope);
     }
 
     /**

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathDependencySelector.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathDependencySelector.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+import java.util.Objects;
+
+import org.eclipse.aether.collection.DependencyCollectionContext;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+/**
+ * Selects dependencies by their effective Maven classpath scope while the graph is being collected. Filtering after
+ * conflict resolution is too late because dependencies excluded from one classpath can otherwise affect mediation in
+ * another classpath.
+ */
+final class ClasspathDependencySelector implements DependencySelector {
+    private final ClasspathScope classpathScope;
+
+    private final String parentScope;
+
+    ClasspathDependencySelector(ClasspathScope classpathScope) {
+        this(classpathScope, null);
+    }
+
+    private ClasspathDependencySelector(ClasspathScope classpathScope, String parentScope) {
+        this.classpathScope = Objects.requireNonNull(classpathScope);
+        this.parentScope = parentScope;
+    }
+
+    @Override
+    public boolean selectDependency(Dependency dependency) {
+        return classpathScope.includes(deriveScope(parentScope, dependency.getScope()));
+    }
+
+    @Override
+    public DependencySelector deriveChildSelector(DependencyCollectionContext context) {
+        Dependency dependency = context.getDependency();
+        if (dependency == null) {
+            return this;
+        }
+        return new ClasspathDependencySelector(classpathScope, deriveScope(parentScope, dependency.getScope()));
+    }
+
+    // Keep this in sync with Resolver's legacy JavaScopeDeriver. Its callable context is not binary compatible
+    // between Resolver 1.x and 2.x, while this plugin must run with both Maven 3 and Maven 4.
+    static String deriveScope(String parentScope, String childScope) {
+        String child = childScope == null || childScope.isEmpty() ? JavaScopes.COMPILE : childScope;
+        if (JavaScopes.SYSTEM.equals(child) || JavaScopes.TEST.equals(child)) {
+            return child;
+        } else if (parentScope == null || parentScope.isEmpty() || JavaScopes.COMPILE.equals(parentScope)) {
+            return child;
+        } else if (JavaScopes.TEST.equals(parentScope) || JavaScopes.RUNTIME.equals(parentScope)) {
+            return parentScope;
+        } else if (JavaScopes.SYSTEM.equals(parentScope) || JavaScopes.PROVIDED.equals(parentScope)) {
+            return JavaScopes.PROVIDED;
+        } else {
+            return JavaScopes.RUNTIME;
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathScope.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathScope.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+import java.util.Locale;
+
+import org.eclipse.aether.util.artifact.JavaScopes;
+
+enum ClasspathScope {
+    COMPILE,
+    RUNTIME,
+    TEST;
+
+    static ClasspathScope fromString(String value) {
+        try {
+            return valueOf(value.toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                    "Unknown dependency scope '" + value + "'. Expected one of: compile, runtime, test.", e);
+        }
+    }
+
+    boolean includes(String scope) {
+        String effectiveScope = scope == null || scope.isEmpty() ? JavaScopes.COMPILE : scope;
+        switch (this) {
+            case COMPILE:
+                return JavaScopes.COMPILE.equals(effectiveScope)
+                        || JavaScopes.PROVIDED.equals(effectiveScope)
+                        || JavaScopes.SYSTEM.equals(effectiveScope);
+            case RUNTIME:
+                return JavaScopes.COMPILE.equals(effectiveScope) || JavaScopes.RUNTIME.equals(effectiveScope);
+            case TEST:
+                return true;
+            default:
+                throw new IllegalStateException("Unhandled classpath scope " + this);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return name().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathScope.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathScope.java
@@ -32,7 +32,7 @@ enum ClasspathScope {
             return valueOf(value.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException(
-                    "Unknown dependency scope '" + value + "'. Expected one of: compile, runtime, test.", e);
+                    "Unknown dependency scope '" + value + "'. Expected one of: compile, runtime, test.");
         }
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -37,7 +37,7 @@ import org.apache.maven.plugins.dependency.utils.ResolverUtil;
 import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
 import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
 import org.apache.maven.project.MavenProject;
-import org.eclipse.aether.RepositorySystem;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -94,9 +94,9 @@ public class CopyMojo extends AbstractFromConfigurationMojo {
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
             CopyUtil copyUtil,
-            RepositorySystem repositorySystem,
-            ResolverUtil resolverUtil) {
-        super(session, buildContext, project, artifactHandlerManager, repositorySystem, resolverUtil);
+            ResolverUtil resolverUtil,
+            DependencyCollectorBuilder dependencyCollectorBuilder) {
+        super(session, buildContext, project, artifactHandlerManager, resolverUtil, dependencyCollectorBuilder);
         this.copyUtil = copyUtil;
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/CopyMojo.java
@@ -37,7 +37,7 @@ import org.apache.maven.plugins.dependency.utils.ResolverUtil;
 import org.apache.maven.plugins.dependency.utils.filters.ArtifactItemFilter;
 import org.apache.maven.plugins.dependency.utils.filters.DestFileFilter;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
+import org.eclipse.aether.RepositorySystem;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -94,9 +94,9 @@ public class CopyMojo extends AbstractFromConfigurationMojo {
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
             CopyUtil copyUtil,
-            ResolverUtil resolverUtil,
-            DependencyCollectorBuilder dependencyCollectorBuilder) {
-        super(session, buildContext, project, artifactHandlerManager, resolverUtil, dependencyCollectorBuilder);
+            RepositorySystem repositorySystem,
+            ResolverUtil resolverUtil) {
+        super(session, buildContext, project, artifactHandlerManager, repositorySystem, resolverUtil);
         this.copyUtil = copyUtil;
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/DependencyVersionResolver.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/DependencyVersionResolver.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilderException;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorRequest;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.eclipse.aether.collection.DependencySelector;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.eclipse.aether.util.graph.manager.DependencyManagerUtils;
+import org.eclipse.aether.util.graph.selector.AndDependencySelector;
+import org.eclipse.aether.util.graph.selector.ExclusionDependencySelector;
+import org.eclipse.aether.util.graph.selector.OptionalDependencySelector;
+import org.eclipse.aether.util.graph.selector.ScopeDependencySelector;
+import org.eclipse.aether.util.graph.transformer.ConflictResolver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeDeriver;
+import org.eclipse.aether.util.graph.transformer.JavaScopeSelector;
+import org.eclipse.aether.util.graph.transformer.NearestVersionSelector;
+import org.eclipse.aether.util.graph.transformer.SimpleOptionalitySelector;
+
+final class DependencyVersionResolver {
+    private final MavenSession session;
+
+    private final MavenProject project;
+
+    private final DependencyCollectorBuilder dependencyCollectorBuilder;
+
+    private final Map<ClasspathScope, Map<GroupArtifactKey, List<Artifact>>> artifactIndexByScope =
+            new EnumMap<>(ClasspathScope.class);
+
+    DependencyVersionResolver(
+            MavenSession session, MavenProject project, DependencyCollectorBuilder dependencyCollectorBuilder) {
+        this.session = session;
+        this.project = project;
+        this.dependencyCollectorBuilder = dependencyCollectorBuilder;
+    }
+
+    String resolveVersion(ArtifactItem artifactItem) throws MojoExecutionException {
+        List<Dependency> directDependencies = project.getDependencies();
+        List<Dependency> managedDependencies = project.getDependencyManagement() == null
+                ? Collections.emptyList()
+                : project.getDependencyManagement().getDependencies();
+
+        String modelVersion = findModelVersion(artifactItem, directDependencies, false);
+        if (modelVersion == null) {
+            modelVersion = findModelVersion(artifactItem, managedDependencies, false);
+        }
+        if (modelVersion == null) {
+            modelVersion = findModelVersion(artifactItem, directDependencies, true);
+        }
+        if (modelVersion == null) {
+            modelVersion = findModelVersion(artifactItem, managedDependencies, true);
+        }
+        if (modelVersion != null) {
+            return modelVersion;
+        }
+
+        List<ClasspathScope> requestedScopes = requestedScopes(artifactItem);
+        Map<ClasspathScope, Set<String>> versions = findGraphVersions(artifactItem, requestedScopes, false);
+        if (versions.isEmpty()) {
+            versions = findGraphVersions(artifactItem, requestedScopes, true);
+        }
+        if (!versions.isEmpty()) {
+            return uniqueVersion(artifactItem, versions);
+        }
+
+        String scopeDescription = artifactItem.getDependencyScope() == null
+                ? "compile, runtime, or test dependency graph"
+                : artifactItem.getDependencyScope() + " dependency graph";
+        throw new MojoExecutionException("Unable to find artifact version of " + artifactItem.getGroupId() + ":"
+                + artifactItem.getArtifactId() + " in direct dependencies, dependency management, or the project's "
+                + scopeDescription + ".");
+    }
+
+    private List<ClasspathScope> requestedScopes(ArtifactItem artifactItem) throws MojoExecutionException {
+        String dependencyScope = artifactItem.getDependencyScope();
+        if (dependencyScope == null || dependencyScope.isEmpty()) {
+            List<ClasspathScope> scopes = new ArrayList<>(3);
+            Collections.addAll(scopes, ClasspathScope.COMPILE, ClasspathScope.RUNTIME, ClasspathScope.TEST);
+            return scopes;
+        }
+        try {
+            return Collections.singletonList(ClasspathScope.fromString(dependencyScope));
+        } catch (IllegalArgumentException e) {
+            throw new MojoExecutionException(e.getMessage(), e);
+        }
+    }
+
+    private Map<ClasspathScope, Set<String>> findGraphVersions(
+            ArtifactItem artifactItem, List<ClasspathScope> scopes, boolean looseMatch) throws MojoExecutionException {
+        Map<ClasspathScope, Set<String>> result = new LinkedHashMap<>();
+        GroupArtifactKey key = GroupArtifactKey.from(artifactItem);
+        for (ClasspathScope scope : scopes) {
+            List<Artifact> artifacts = artifactIndex(scope).get(key);
+            Set<String> versions =
+                    artifacts == null ? Collections.emptySet() : matchingVersions(artifactItem, artifacts, looseMatch);
+            if (!versions.isEmpty()) {
+                result.put(scope, versions);
+            }
+        }
+        return result;
+    }
+
+    private String uniqueVersion(ArtifactItem artifactItem, Map<ClasspathScope, Set<String>> versions)
+            throws MojoExecutionException {
+        Set<String> uniqueVersions = versions.values().stream()
+                .flatMap(Collection::stream)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+        if (uniqueVersions.size() == 1) {
+            return uniqueVersions.iterator().next();
+        }
+
+        String selections = versions.entrySet().stream()
+                .map(entry -> entry.getKey() + "=" + String.join(",", entry.getValue()))
+                .collect(Collectors.joining(", "));
+        throw new MojoExecutionException("Dependency graphs select different versions of " + artifactItem.getGroupId()
+                + ":" + artifactItem.getArtifactId() + " (" + selections
+                + "). Set dependencyScope to compile, runtime, or test, or specify version explicitly.");
+    }
+
+    private Map<GroupArtifactKey, List<Artifact>> artifactIndex(ClasspathScope scope) throws MojoExecutionException {
+        Map<GroupArtifactKey, List<Artifact>> cached = artifactIndexByScope.get(scope);
+        if (cached != null) {
+            return cached;
+        }
+
+        ProjectBuildingRequest buildingRequest;
+        if (session.getProjectBuildingRequest() == null) {
+            buildingRequest = new DefaultProjectBuildingRequest();
+            buildingRequest.setRepositorySession(session.getRepositorySession());
+        } else {
+            buildingRequest = new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
+        }
+        buildingRequest.setProject(project);
+
+        DependencyCollectorRequest request = new DependencyCollectorRequest(buildingRequest);
+        request.dependencySelector(dependencySelector(scope));
+        request.dependencyGraphTransformer(new ConflictResolver(
+                new NearestVersionSelector(),
+                new JavaScopeSelector(),
+                new SimpleOptionalitySelector(),
+                new JavaScopeDeriver()));
+        request.addConfigProperty(ConflictResolver.CONFIG_PROP_VERBOSE, false);
+        request.addConfigProperty(DependencyManagerUtils.CONFIG_PROP_VERBOSE, false);
+
+        try {
+            DependencyNode root = dependencyCollectorBuilder.collectDependencyGraph(request);
+            List<Artifact> collected = new ArrayList<>();
+            collectArtifacts(root, collected, true);
+            Map<GroupArtifactKey, List<Artifact>> index = indexArtifacts(collected);
+            artifactIndexByScope.put(scope, index);
+            return index;
+        } catch (DependencyCollectorBuilderException e) {
+            throw new MojoExecutionException("Unable to collect the project's " + scope + " dependency graph.", e);
+        }
+    }
+
+    private DependencySelector dependencySelector(ClasspathScope scope) {
+        return new AndDependencySelector(
+                new ClasspathDependencySelector(scope),
+                new ScopeDependencySelector(JavaScopes.TEST, JavaScopes.PROVIDED),
+                new OptionalDependencySelector(),
+                new ExclusionDependencySelector());
+    }
+
+    private void collectArtifacts(DependencyNode node, List<Artifact> artifacts, boolean root) {
+        if (!root && node.getArtifact() != null) {
+            artifacts.add(node.getArtifact());
+        }
+        for (DependencyNode child : node.getChildren()) {
+            collectArtifacts(child, artifacts, false);
+        }
+    }
+
+    static Map<GroupArtifactKey, List<Artifact>> indexArtifacts(Collection<Artifact> artifacts) {
+        Map<GroupArtifactKey, List<Artifact>> index = new LinkedHashMap<>();
+        for (Artifact artifact : artifacts) {
+            index.computeIfAbsent(GroupArtifactKey.from(artifact), key -> new ArrayList<>())
+                    .add(artifact);
+        }
+        for (Map.Entry<GroupArtifactKey, List<Artifact>> entry : index.entrySet()) {
+            entry.setValue(Collections.unmodifiableList(entry.getValue()));
+        }
+        return Collections.unmodifiableMap(index);
+    }
+
+    static Set<String> matchingVersions(ArtifactItem artifactItem, List<Artifact> artifacts, boolean looseMatch) {
+        return artifacts.stream()
+                .filter(artifact -> looseMatch
+                        || (Objects.equals(artifact.getClassifier(), artifactItem.getClassifier())
+                                && Objects.equals(artifact.getType(), artifactItem.getType())))
+                .map(Artifact::getVersion)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private String findModelVersion(ArtifactItem artifactItem, List<Dependency> dependencies, boolean looseMatch) {
+        for (Dependency dependency : dependencies) {
+            if (Objects.equals(dependency.getArtifactId(), artifactItem.getArtifactId())
+                    && Objects.equals(dependency.getGroupId(), artifactItem.getGroupId())
+                    && (looseMatch || Objects.equals(dependency.getClassifier(), artifactItem.getClassifier()))
+                    && (looseMatch || Objects.equals(dependency.getType(), artifactItem.getType()))) {
+                return dependency.getVersion();
+            }
+        }
+        return null;
+    }
+
+    static final class GroupArtifactKey {
+        private final String groupId;
+
+        private final String artifactId;
+
+        private GroupArtifactKey(String groupId, String artifactId) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+        }
+
+        static GroupArtifactKey from(ArtifactItem artifactItem) {
+            return new GroupArtifactKey(artifactItem.getGroupId(), artifactItem.getArtifactId());
+        }
+
+        static GroupArtifactKey from(Artifact artifact) {
+            return new GroupArtifactKey(artifact.getGroupId(), artifact.getArtifactId());
+        }
+
+        @Override
+        public boolean equals(Object object) {
+            if (this == object) {
+                return true;
+            }
+            if (!(object instanceof GroupArtifactKey)) {
+                return false;
+            }
+            GroupArtifactKey that = (GroupArtifactKey) object;
+            return Objects.equals(groupId, that.groupId) && Objects.equals(artifactId, that.artifactId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(groupId, artifactId);
+        }
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -37,8 +37,8 @@ import org.apache.maven.plugins.dependency.utils.filters.MarkerFileFilter;
 import org.apache.maven.plugins.dependency.utils.markers.MarkerHandler;
 import org.apache.maven.plugins.dependency.utils.markers.UnpackFileMarkerHandler;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
+import org.eclipse.aether.RepositorySystem;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -112,9 +112,9 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
             UnpackUtil unpackUtil,
-            ResolverUtil resolverUtil,
-            DependencyCollectorBuilder dependencyCollectorBuilder) {
-        super(session, buildContext, project, artifactHandlerManager, resolverUtil, dependencyCollectorBuilder);
+            RepositorySystem repositorySystem,
+            ResolverUtil resolverUtil) {
+        super(session, buildContext, project, artifactHandlerManager, repositorySystem, resolverUtil);
         this.unpackUtil = unpackUtil;
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromConfiguration/UnpackMojo.java
@@ -37,8 +37,8 @@ import org.apache.maven.plugins.dependency.utils.filters.MarkerFileFilter;
 import org.apache.maven.plugins.dependency.utils.markers.MarkerHandler;
 import org.apache.maven.plugins.dependency.utils.markers.UnpackFileMarkerHandler;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.dependency.graph.DependencyCollectorBuilder;
 import org.codehaus.plexus.components.io.filemappers.FileMapper;
-import org.eclipse.aether.RepositorySystem;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
@@ -112,9 +112,9 @@ public class UnpackMojo extends AbstractFromConfigurationMojo {
             MavenProject project,
             ArtifactHandlerManager artifactHandlerManager,
             UnpackUtil unpackUtil,
-            RepositorySystem repositorySystem,
-            ResolverUtil resolverUtil) {
-        super(session, buildContext, project, artifactHandlerManager, repositorySystem, resolverUtil);
+            ResolverUtil resolverUtil,
+            DependencyCollectorBuilder dependencyCollectorBuilder) {
+        super(session, buildContext, project, artifactHandlerManager, resolverUtil, dependencyCollectorBuilder);
         this.unpackUtil = unpackUtil;
     }
 

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
@@ -137,6 +137,18 @@ public class ResolverUtil {
     }
 
     /**
+     * Returns the current repository session, optionally using an alternate local repository.
+     *
+     * @param localRepositoryDirectory alternate local repository directory, or {@code null}
+     * @return repository system session
+     */
+    public RepositorySystemSession repositorySystemSession(File localRepositoryDirectory) {
+        return localRepositoryDirectory == null
+                ? mavenSessionProvider.get().getRepositorySession()
+                : localRepositorySession(localRepositoryDirectory);
+    }
+
+    /**
      * Collects the transitive dependencies.
      *
      * @param dependency a dependency for collections

--- a/src/site/markdown/examples/copying-artifacts.md.vm
+++ b/src/site/markdown/examples/copying-artifacts.md.vm
@@ -81,7 +81,12 @@ Artifacts are resolved from the following sources in order:
 
 If the artifact cannot be resolved from the above sources then the build will fail.
 
-If the artifact is also listed as a dependency, the `version` of the `artifactItem` will default to the version from the `dependencies` or `dependencyManagement`, e.g.
+If the artifact is also a direct dependency or is listed in `dependencyManagement`, the `version` of the
+`artifactItem` may be omitted. The plugin checks those model entries first, preferring an exact match on type and
+classifier before matching only group ID and artifact ID. Otherwise, a version may be inferred from a transitive
+dependency. For that fallback, the plugin compares the versions selected by the project's compile, runtime, and test
+dependency graphs. If the graphs select different versions, use `dependencyScope` with `compile`, `runtime`, or `test`
+to choose the intended graph, e.g.
 
 ```xml
 <project>

--- a/src/site/markdown/examples/unpacking-artifacts.md.vm
+++ b/src/site/markdown/examples/unpacking-artifacts.md.vm
@@ -76,6 +76,12 @@ This is pretty similar to the [Copying Specific Artifacts](./copying-artifacts.h
 
 And after invoking `mvn package`, the artifacts are unpacked. Because checking the existence of an unpacked archive is difficult to do reliably, marker files are used instead. The location of the marker files is controlled by the [markersDirectory](../unpack-dependencies-mojo.html#markersDirectory) parameter.
 
+If an artifact is also a direct project dependency or is listed in `dependencyManagement`, its `version` may be
+omitted. The plugin checks those model entries first, preferring an exact type and classifier match before matching only
+group ID and artifact ID. Otherwise, a version may be inferred from a transitive dependency. For that fallback, the
+plugin compares the versions selected by the compile, runtime, and test dependency graphs. If those graphs select
+different versions, set `dependencyScope` on the `artifactItem` to `compile`, `runtime`, or `test`.
+
 # <a id="Unpacking_from_the_command_line"></a>Unpacking from the command line:
 
 If you intend to configure this mojo for execution on the command line using:

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathDependencySelectorTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/ClasspathDependencySelectorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.util.artifact.JavaScopes;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClasspathDependencySelectorTest {
+    @Test
+    void providedDependenciesAreOnCompileAndTestClasspaths() {
+        Dependency provided = dependency(JavaScopes.PROVIDED);
+
+        assertTrue(new ClasspathDependencySelector(ClasspathScope.COMPILE).selectDependency(provided));
+        assertFalse(new ClasspathDependencySelector(ClasspathScope.RUNTIME).selectDependency(provided));
+        assertTrue(new ClasspathDependencySelector(ClasspathScope.TEST).selectDependency(provided));
+    }
+
+    @Test
+    void derivesTransitiveScopesLikeResolver() {
+        assertEquals(
+                JavaScopes.PROVIDED, ClasspathDependencySelector.deriveScope(JavaScopes.PROVIDED, JavaScopes.COMPILE));
+        assertEquals(
+                JavaScopes.RUNTIME, ClasspathDependencySelector.deriveScope(JavaScopes.RUNTIME, JavaScopes.COMPILE));
+        assertEquals(JavaScopes.TEST, ClasspathDependencySelector.deriveScope(JavaScopes.COMPILE, JavaScopes.TEST));
+        assertEquals(
+                JavaScopes.RUNTIME, ClasspathDependencySelector.deriveScope(JavaScopes.COMPILE, JavaScopes.RUNTIME));
+    }
+
+    private Dependency dependency(String scope) {
+        return new Dependency(new DefaultArtifact("groupId:artifactId:jar:1.0"), scope);
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/DependencyVersionResolverTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/DependencyVersionResolverTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.fromConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DependencyVersionResolverTest {
+    @Test
+    void indexesAllVariantsUnderTheirGroupAndArtifactId() {
+        Artifact main = artifact("group", "artifact", "1.0", "jar", null);
+        Artifact sources = artifact("group", "artifact", "2.0", "jar", "sources");
+        Artifact other = artifact("group", "other", "3.0", "jar", null);
+
+        Map<DependencyVersionResolver.GroupArtifactKey, List<Artifact>> index =
+                DependencyVersionResolver.indexArtifacts(Arrays.asList(main, sources, other));
+
+        assertEquals(Arrays.asList(main, sources), index.get(DependencyVersionResolver.GroupArtifactKey.from(main)));
+        assertEquals(Arrays.asList(other), index.get(DependencyVersionResolver.GroupArtifactKey.from(other)));
+        assertThrows(UnsupportedOperationException.class, () -> index.clear());
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> index.get(DependencyVersionResolver.GroupArtifactKey.from(main))
+                        .clear());
+    }
+
+    @Test
+    void matchesExactVariantBeforeUsingAllGaVariants() {
+        Artifact main = artifact("group", "artifact", "1.0", "jar", null);
+        Artifact sources = artifact("group", "artifact", "2.0", "jar", "sources");
+        List<Artifact> variants = Arrays.asList(main, sources);
+
+        ArtifactItem item = new ArtifactItem();
+        item.setGroupId("group");
+        item.setArtifactId("artifact");
+        item.setType("jar");
+        item.setClassifier("sources");
+
+        assertIterableEquals(Arrays.asList("2.0"), DependencyVersionResolver.matchingVersions(item, variants, false));
+        assertIterableEquals(
+                Arrays.asList("1.0", "2.0"), DependencyVersionResolver.matchingVersions(item, variants, true));
+    }
+
+    private Artifact artifact(String groupId, String artifactId, String version, String type, String classifier) {
+        return new DefaultArtifact(
+                groupId, artifactId, version, null, type, classifier, new DefaultArtifactHandler(type));
+    }
+}

--- a/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestArtifactItem.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromConfiguration/TestArtifactItem.java
@@ -48,4 +48,13 @@ class TestArtifactItem {
         // check type default
         assertEquals("jar", item.getType());
     }
+
+    @Test
+    void testDependencyScope() {
+        ArtifactItem item = new ArtifactItem();
+
+        item.setDependencyScope("runtime");
+
+        assertEquals("runtime", item.getDependencyScope());
+    }
 }


### PR DESCRIPTION
## Summary

Allow `dependency:copy` and `dependency:unpack` artifact items to omit their version when the artifact is present only as a transitive project dependency.

The existing direct-dependency and dependency-management lookups remain authoritative. If neither supplies a version, the plugin lazily collects the requested compile, runtime, or test dependency graph through Maven Resolver and looks up the selected artifact version. An optional `dependencyScope` setting resolves cases where different classpaths select different versions; without it, conflicting selections are reported rather than guessed.

Artifact matching first uses the complete group ID, artifact ID, type, and classifier coordinates and then preserves the existing GA fallback. The resolved graphs are cached per scope in immutable GA-indexed maps. Existing relocation behavior is retained because the original model coordinates are checked before Resolver's post-relocation graph.

This implementation uses the Maven shared dependency graph APIs supported by both Maven 3.x and Maven 4.x.

Fixes #1240.

## Verification

- `mvn verify` — 415 tests passed, with one existing skip.
- `mvn -Prun-its verify` — all 103 integration projects passed.
- Focused `mdep-726-*`, `copy-relocation`, and `unpack-relocation` integration tests passed with:
  - Maven 3.6.3 on JDK 8
  - Maven 3.9.16 on JDK 21
  - Maven 4.0.0-rc-5 on JDK 21
- Spotless, Checkstyle, Apache RAT, dependency analysis, and `git diff --check` passed.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
