### PR TITLE
[MDEP-870] Overwrite copied artifact POMs

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/CopyDependenciesMojo.java
@@ -170,9 +170,9 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
         }
 
         if (isCopyPom() && !useRepositoryLayout) {
-            copyPoms(getOutputDirectory(), artifacts, this.stripVersion);
-            copyPoms(getOutputDirectory(), skippedArtifacts, this.stripVersion, this.stripClassifier);
+            copyPoms(getOutputDirectory(), artifacts, this.stripVersion, this.stripClassifier, true);
             // Artifacts that already exist may not yet have poms
+            copyPoms(getOutputDirectory(), skippedArtifacts, this.stripVersion, this.stripClassifier, false);
         }
     }
 
@@ -341,6 +341,12 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
      */
     public void copyPoms(File destDir, Set<Artifact> artifacts, boolean removeVersion, boolean removeClassifier)
             throws MojoExecutionException {
+        copyPoms(destDir, artifacts, removeVersion, removeClassifier, false);
+    }
+
+    private void copyPoms(
+            File destDir, Set<Artifact> artifacts, boolean removeVersion, boolean removeClassifier, boolean overwrite)
+            throws MojoExecutionException {
 
         for (Artifact artifact : artifacts) {
             Artifact pomArtifact = getResolvedPomArtifact(artifact);
@@ -353,7 +359,7 @@ public class CopyDependenciesMojo extends AbstractFromDependenciesMojo {
                         destDir,
                         DependencyUtil.getFormattedFileName(
                                 pomArtifact, removeVersion, prependGroupId, useBaseVersion, removeClassifier));
-                if (!pomDestFile.exists()) {
+                if (overwrite || !pomDestFile.exists()) {
                     try {
                         copyUtil.copyArtifactFile(pomArtifact, pomDestFile);
                     } catch (IOException e) {

--- a/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/fromDependencies/TestCopyDependenciesMojo.java
@@ -22,6 +22,8 @@ import javax.inject.Inject;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -47,6 +49,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
 
 @MojoTest(realRepositorySession = true)
 class TestCopyDependenciesMojo {
@@ -773,6 +778,82 @@ class TestCopyDependenciesMojo {
             File file = new File(mojo.outputDirectory, fileName.substring(0, fileName.length() - 4) + ".pom");
             assertTrue(file.exists(), file + " doesn't exist");
         }
+    }
+
+    @Test
+    @InjectMojo(goal = "copy-dependencies")
+    void testCopyPomOverwritesExistingPomWhenArtifactIsCopied(CopyDependenciesMojo mojo) throws Exception {
+        Artifact artifact = stubFactory.createArtifact("org.example", "artifact", "2.0", Artifact.SCOPE_COMPILE);
+        Artifact pomArtifact =
+                stubFactory.createArtifact("org.example", "artifact", "2.0", Artifact.SCOPE_COMPILE, "pom", null);
+        writeFile(artifact.getFile(), "new jar");
+        writeFile(pomArtifact.getFile(), "new pom");
+
+        Set<Artifact> artifacts = new HashSet<>();
+        artifacts.add(artifact);
+        mojo.getProject().setArtifacts(artifacts);
+
+        CopyDependenciesMojo mojoSpy = spy(mojo);
+        doReturn(pomArtifact).when(mojoSpy).getResolvedPomArtifact(any(Artifact.class));
+        mojoSpy.setCopyPom(true);
+        mojoSpy.setStripVersion(true);
+        mojoSpy.overWriteReleases = true;
+        mojoSpy.overWriteIfNewer = false;
+
+        File jarDestination = new File(mojoSpy.outputDirectory, "artifact.jar");
+        File pomDestination = new File(mojoSpy.outputDirectory, "artifact.pom");
+        writeFile(jarDestination, "old jar");
+        writeFile(pomDestination, "old pom");
+
+        mojoSpy.execute();
+
+        assertEquals("new jar", readFile(jarDestination));
+        assertEquals("new pom", readFile(pomDestination));
+    }
+
+    @Test
+    @InjectMojo(goal = "copy-dependencies")
+    void testCopyPomForSkippedArtifactOnlyWhenMissing(CopyDependenciesMojo mojo) throws Exception {
+        Artifact artifact = stubFactory.createArtifact("org.example", "artifact", "2.0", Artifact.SCOPE_COMPILE);
+        Artifact pomArtifact =
+                stubFactory.createArtifact("org.example", "artifact", "2.0", Artifact.SCOPE_COMPILE, "pom", null);
+        writeFile(artifact.getFile(), "new jar");
+        writeFile(pomArtifact.getFile(), "new pom");
+
+        Set<Artifact> artifacts = new HashSet<>();
+        artifacts.add(artifact);
+        mojo.getProject().setArtifacts(artifacts);
+
+        CopyDependenciesMojo mojoSpy = spy(mojo);
+        doReturn(pomArtifact).when(mojoSpy).getResolvedPomArtifact(any(Artifact.class));
+        mojoSpy.setCopyPom(true);
+        mojoSpy.setStripVersion(true);
+        mojoSpy.overWriteReleases = false;
+        mojoSpy.overWriteIfNewer = false;
+
+        File jarDestination = new File(mojoSpy.outputDirectory, "artifact.jar");
+        File pomDestination = new File(mojoSpy.outputDirectory, "artifact.pom");
+        writeFile(jarDestination, "old jar");
+
+        mojoSpy.execute();
+
+        assertEquals("old jar", readFile(jarDestination));
+        assertEquals("new pom", readFile(pomDestination));
+
+        writeFile(pomDestination, "existing pom");
+        mojoSpy.execute();
+
+        assertEquals("old jar", readFile(jarDestination));
+        assertEquals("existing pom", readFile(pomDestination));
+    }
+
+    private static void writeFile(File file, String contents) throws IOException {
+        Files.createDirectories(file.getParentFile().toPath());
+        Files.write(file.toPath(), contents.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String readFile(File file) throws IOException {
+        return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
     }
 
     @Test


### PR DESCRIPTION
## Summary

When `dependency:copy-dependencies` copies an artifact, overwrite its associated POM as well. This prevents version-stripped output from containing a JAR from one version and a pre-existing POM from another version.

Artifacts skipped by the configured overwrite policy retain the existing MDEP-164 behavior: their POM is copied only when it is missing.

## Root cause

Copied and skipped artifacts shared the same `copyPoms` path, which unconditionally ignored an existing destination POM. As a result, an artifact selected for replacement could overwrite the versionless JAR while leaving its old versionless POM untouched.

Fixes #1370

## Verification

- The new regression test failed before the production change with `expected: <new pom> but was: <old pom>`.
- Maven 3: `mvn verify` — 412 tests, 0 failures/errors, 1 skipped.
- Maven 4 with JDK 21: `mvn verify` — 412 tests, 0 failures/errors, 1 skipped.
- Focused Invoker build: `mvn -DskipTests -Prun-its -Dinvoker.test=copy-dependencies verify` — 1 passed.
- Exact Commons Lang 3.12.0 to 3.14.0 reproducer: the resulting versionless JAR and POM checksums both match 3.14.0.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [ ] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
