### PR TITLE
[MDEP-425] List plugin repositories

### DIFF
--- a/src/it/projects/list-repositories/pom.xml
+++ b/src/it/projects/list-repositories/pom.xml
@@ -43,6 +43,13 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>fake-plugin-repository</id>
+      <url>http://localhost:3456</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.maven</groupId>

--- a/src/it/projects/list-repositories/verify.groovy
+++ b/src/it/projects/list-repositories/verify.groovy
@@ -23,6 +23,8 @@ assert file.exists()
 String buildLog = file.getText( "UTF-8" )
 assert buildLog.contains( 'Project remote repositories used by this build:')
 assert buildLog.contains( '* fake-remote-repository (http://localhost:2345, default, releases+snapshots)')
+assert buildLog.contains( 'Plugin repositories used by this build:' )
+assert buildLog.contains( '* fake-plugin-repository (http://localhost:3456, default, releases+snapshots)' )
 assert buildLog.contains( '* sonatype-nexus-snapshots (https://oss.sonatype.org/content/repositories/snapshots, default, snapshots) mirrored by mrm-maven-plugin')
 if (!mavenVersion.startsWith('4.')) {
     // Maven 4 drop central repo from default super pom - so model doesn't have it

--- a/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/ListRepositoriesMojo.java
@@ -48,8 +48,8 @@ import org.eclipse.aether.util.graph.visitor.TreeDependencyVisitor;
 import org.sonatype.plexus.build.incremental.BuildContext;
 
 /**
- * Goal that collects all project dependencies and then lists the repositories used by the build and by the transitive
- * dependencies.
+ * Goal that collects all project dependencies and then lists the dependency repositories used by the build and
+ * transitive dependencies, along with the plugin repositories used by the build.
  *
  * @author <a href="mailto:brianf@apache.org">Brian Fox</a>
  * @since 2.2
@@ -109,21 +109,18 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
                 }
             }));
 
-            if (repositories.isEmpty()) {
+            Set<RemoteRepository> pluginRepositories =
+                    new HashSet<>(Optional.ofNullable(getProject().getRemotePluginRepositories())
+                            .orElseGet(Collections::emptyList));
+
+            if (repositories.isEmpty() && pluginRepositories.isEmpty()) {
                 getLog().info("No remote repository is used by this build." + System.lineSeparator());
                 return;
             }
 
             StringBuilder message = new StringBuilder();
-
-            Map<Boolean, List<RemoteRepository>> repoGroupByMirrors = repositories.stream()
-                    .collect(Collectors.groupingBy(
-                            repo -> repo.getMirroredRepositories().isEmpty()));
-
-            prepareRemoteRepositoriesList(
-                    message, repoGroupByMirrors.getOrDefault(Boolean.TRUE, Collections.emptyList()));
-            prepareRemoteMirrorRepositoriesList(
-                    message, repoGroupByMirrors.getOrDefault(Boolean.FALSE, Collections.emptyList()));
+            prepareRemoteRepositoriesList(message, "Project remote repositories used by this build:", repositories);
+            prepareRemoteRepositoriesList(message, "Plugin repositories used by this build:", pluginRepositories);
 
             getLog().info(message);
 
@@ -163,11 +160,21 @@ public class ListRepositoriesMojo extends AbstractDependencyMojo {
     }
 
     private void prepareRemoteRepositoriesList(
-            StringBuilder message, Collection<RemoteRepository> remoteProjectRepositories) {
+            StringBuilder message, String heading, Collection<RemoteRepository> repositories) {
+        if (repositories.isEmpty()) {
+            return;
+        }
 
-        message.append("Project remote repositories used by this build:").append(System.lineSeparator());
+        message.append(heading).append(System.lineSeparator());
 
-        remoteProjectRepositories.forEach(
-                repo -> message.append(" * ").append(repo).append(System.lineSeparator()));
+        Map<Boolean, List<RemoteRepository>> repoGroupByMirrors = repositories.stream()
+                .collect(Collectors.groupingBy(
+                        repo -> repo.getMirroredRepositories().isEmpty()));
+
+        repoGroupByMirrors
+                .getOrDefault(Boolean.TRUE, Collections.emptyList())
+                .forEach(repo -> message.append(" * ").append(repo).append(System.lineSeparator()));
+        prepareRemoteMirrorRepositoriesList(
+                message, repoGroupByMirrors.getOrDefault(Boolean.FALSE, Collections.emptyList()));
     }
 }


### PR DESCRIPTION
Fixes #868.

The `list-repositories` goal currently seeds dependency collection from the project's dependency repositories and reports repositories discovered in that dependency graph. Plugin repositories are available separately from the effective Maven project, so they never enter that collection and are omitted from the output.

This change reads the effective plugin repositories directly from `MavenProject`, then prints them in a distinct, mirror-aware section. The existing integration test now configures a plugin repository and verifies that both dependency and plugin repository sections are reported.

Validation:

- Confirmed the new integration-test assertions fail before the runtime change.
- `mvn verify` with Maven 3.9.16 and JDK 17.
- `mvn -Prun-its verify` with Maven 3.9.16 and JDK 17: 410 tests passed with one existing skip; all 99 Invoker builds passed.
- Focused `list-repositories` IT with Maven 4.0.0-rc-5 and JDK 17.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
