### PR TITLE
[MDEP-927] Make dependency:tree excludes prune subtrees

### DIFF
--- a/src/it/projects/tree-excluded/expected-included-survives.txt
+++ b/src/it/projects/tree-excluded/expected-included-survives.txt
@@ -1,0 +1,4 @@
+org.apache.maven.its.dependency:test:jar:1.0-SNAPSHOT
+\- org.apache.maven:maven-project:jar:2.0.6:compile
+   \- org.apache.maven:maven-artifact-manager:jar:2.0.6:compile
+      \- org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-2:compile

--- a/src/it/projects/tree-excluded/expected-v4.txt
+++ b/src/it/projects/tree-excluded/expected-v4.txt
@@ -7,7 +7,4 @@ org.apache.maven.its.dependency:test:jar:1.0-SNAPSHOT
    |  +- org.apache.maven:maven-repository-metadata:jar:2.0.6:compile
    |  \- org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-2:compile
    +- org.apache.maven:maven-plugin-registry:jar:2.0.6:compile
-   +- org.apache.maven:maven-artifact:jar:2.0.6:compile
-   \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
-      +- junit:junit:jar:3.8.1:compile
-      \- classworlds:classworlds:jar:1.1:compile
+   \- org.apache.maven:maven-artifact:jar:2.0.6:compile

--- a/src/it/projects/tree-excluded/expected.txt
+++ b/src/it/projects/tree-excluded/expected.txt
@@ -7,7 +7,4 @@ org.apache.maven.its.dependency:test:jar:1.0-SNAPSHOT
    |  +- org.apache.maven:maven-repository-metadata:jar:2.0.6:compile
    |  \- org.apache.maven.wagon:wagon-provider-api:jar:1.0-beta-2:compile
    +- org.apache.maven:maven-plugin-registry:jar:2.0.6:compile
-   +- org.apache.maven:maven-artifact:jar:2.0.6:compile
-   \- org.codehaus.plexus:plexus-container-default:jar:1.0-alpha-9-stable-1:compile
-      +- junit:junit:jar:3.8.1:compile
-      \- classworlds:classworlds:jar:1.1-alpha-2:compile
+   \- org.apache.maven:maven-artifact:jar:2.0.6:compile

--- a/src/it/projects/tree-excluded/test-included-excluded.properties
+++ b/src/it/projects/tree-excluded/test-included-excluded.properties
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,11 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.1 = test.properties
-
-invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.2 = test-included-excluded.properties
-
-invoker.goals.3 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.3 = test-included-survives.properties
+outputFile = target/included-excluded.txt
+includes = junit:junit
+excludes = org.codehaus.plexus:*

--- a/src/it/projects/tree-excluded/test-included-survives.properties
+++ b/src/it/projects/tree-excluded/test-included-survives.properties
@@ -5,9 +5,9 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -15,11 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals.1 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.1 = test.properties
-
-invoker.goals.2 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.2 = test-included-excluded.properties
-
-invoker.goals.3 = ${project.groupId}:${project.artifactId}:${project.version}:tree
-invoker.userPropertiesFile.3 = test-included-survives.properties
+outputFile = target/included-survives.txt
+includes = :wagon*
+excludes = org.codehaus.plexus:*

--- a/src/it/projects/tree-excluded/verify.groovy
+++ b/src/it/projects/tree-excluded/verify.groovy
@@ -25,4 +25,9 @@ def expected = mavenVersion.startsWith('4.') ? "expected-v4.txt" : "expected.txt
 assertThat(new File(basedir, "target/tree.txt"))
         .hasSameTextualContentAs(new File(basedir, expected))
 
+assertThat(new File(basedir, "target/included-excluded.txt").text).isEmpty()
+
+assertThat(new File(basedir, "target/included-survives.txt"))
+        .hasSameTextualContentAs(new File(basedir, "expected-included-survives.txt"))
+
 return true

--- a/src/main/java/org/apache/maven/plugins/dependency/tree/PruningDependencyNodeVisitor.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/tree/PruningDependencyNodeVisitor.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.tree;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.filter.DependencyNodeFilter;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+
+/**
+ * A dependency node visitor that delegates accepted nodes and prunes rejected nodes and their descendants.
+ */
+final class PruningDependencyNodeVisitor implements DependencyNodeVisitor {
+    private final DependencyNodeVisitor visitor;
+
+    private final DependencyNodeFilter filter;
+
+    private final Deque<Boolean> acceptedNodes = new ArrayDeque<>();
+
+    PruningDependencyNodeVisitor(DependencyNodeVisitor visitor, DependencyNodeFilter filter) {
+        this.visitor = visitor;
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean visit(DependencyNode node) {
+        boolean accepted = filter.accept(node);
+        acceptedNodes.push(accepted);
+        return accepted && visitor.visit(node);
+    }
+
+    @Override
+    public boolean endVisit(DependencyNode node) {
+        return !acceptedNodes.pop() || visitor.endVisit(node);
+    }
+}

--- a/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/tree/TreeMojo.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -49,7 +48,6 @@ import org.apache.maven.shared.dependency.graph.DependencyGraphBuilder;
 import org.apache.maven.shared.dependency.graph.DependencyGraphBuilderException;
 import org.apache.maven.shared.dependency.graph.DependencyNode;
 import org.apache.maven.shared.dependency.graph.filter.AncestorOrSelfDependencyNodeFilter;
-import org.apache.maven.shared.dependency.graph.filter.AndDependencyNodeFilter;
 import org.apache.maven.shared.dependency.graph.filter.ArtifactDependencyNodeFilter;
 import org.apache.maven.shared.dependency.graph.filter.DependencyNodeFilter;
 import org.apache.maven.shared.dependency.graph.traversal.CollectingDependencyNodeVisitor;
@@ -153,6 +151,8 @@ public class TreeMojo extends AbstractMojo {
      * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
      * </p>
+     * Paths leading to included artifacts are retained. If an artifact is also beneath a subtree matched by
+     * {@link #excludes}, the exclusion takes precedence and the artifact is not included.
      *
      * @see StrictPatternIncludesArtifactFilter
      * @since 2.0-alpha-6
@@ -174,6 +174,8 @@ public class TreeMojo extends AbstractMojo {
      * For example, <code>org.apache.*</code> will match all artifacts whose group id starts with
      * <code>org.apache.</code>, and <code>:::*-SNAPSHOT</code> will match all snapshot artifacts.
      * </p>
+     * A matching artifact and its entire dependency subtree are removed from the serialized dependency tree.
+     * Exclusions are applied before {@link #includes} and take precedence.
      *
      * @see StrictPatternExcludesArtifactFilter
      * @since 2.0-alpha-6
@@ -333,16 +335,25 @@ public class TreeMojo extends AbstractMojo {
         // TODO: remove the need for this when the serializer can calculate last nodes from visitor calls only
         visitor = new BuildingDependencyNodeVisitor(visitor);
 
-        DependencyNodeFilter filter = createDependencyNodeFilter();
+        DependencyNodeFilter includesFilter = createIncludesDependencyNodeFilter();
+        DependencyNodeFilter excludesFilter = createExcludesDependencyNodeFilter();
 
-        if (filter != null) {
+        if (includesFilter != null) {
             CollectingDependencyNodeVisitor collectingVisitor = new CollectingDependencyNodeVisitor();
-            DependencyNodeVisitor firstPassVisitor = new FilteringDependencyNodeVisitor(collectingVisitor, filter);
+            DependencyNodeVisitor firstPassVisitor =
+                    new FilteringDependencyNodeVisitor(collectingVisitor, includesFilter);
+            if (excludesFilter != null) {
+                firstPassVisitor = new PruningDependencyNodeVisitor(firstPassVisitor, excludesFilter);
+            }
             theRootNode.accept(firstPassVisitor);
 
             DependencyNodeFilter secondPassFilter =
                     new AncestorOrSelfDependencyNodeFilter(collectingVisitor.getNodes());
             visitor = new FilteringDependencyNodeVisitor(visitor, secondPassFilter);
+        }
+
+        if (excludesFilter != null) {
+            visitor = new PruningDependencyNodeVisitor(visitor, excludesFilter);
         }
 
         theRootNode.accept(visitor);
@@ -397,27 +408,25 @@ public class TreeMojo extends AbstractMojo {
      *
      * @return the dependency node filter, or <code>null</code> if none required
      */
-    private DependencyNodeFilter createDependencyNodeFilter() {
-        List<DependencyNodeFilter> filters = new ArrayList<>();
-
-        // filter includes
+    private DependencyNodeFilter createIncludesDependencyNodeFilter() {
         if (includes != null && !includes.isEmpty()) {
-
             getLog().debug("+ Filtering dependency tree by artifact include patterns: " + includes);
 
             ArtifactFilter artifactFilter = new StrictPatternIncludesArtifactFilter(includes);
-            filters.add(new ArtifactDependencyNodeFilter(artifactFilter));
+            return new ArtifactDependencyNodeFilter(artifactFilter);
         }
 
-        // filter excludes
-        if (excludes != null && !excludes.isEmpty()) {
+        return null;
+    }
 
+    private DependencyNodeFilter createExcludesDependencyNodeFilter() {
+        if (excludes != null && !excludes.isEmpty()) {
             getLog().debug("+ Filtering dependency tree by artifact exclude patterns: " + excludes);
 
             ArtifactFilter artifactFilter = new StrictPatternExcludesArtifactFilter(excludes);
-            filters.add(new ArtifactDependencyNodeFilter(artifactFilter));
+            return new ArtifactDependencyNodeFilter(artifactFilter);
         }
 
-        return filters.isEmpty() ? null : new AndDependencyNodeFilter(filters);
+        return null;
     }
 }

--- a/src/site/markdown/examples/filtering-the-dependency-tree.md
+++ b/src/site/markdown/examples/filtering-the-dependency-tree.md
@@ -64,6 +64,9 @@ The dependency tree can also be filtered to remove specific dependencies. For ex
 mvn dependency:tree -Dexcludes=org.codehaus.plexus
 ```
 
+A dependency matching an exclude pattern and its entire dependency subtree are removed from the serialized tree.
+This affects only the displayed tree; it does not change the project's dependency resolution.
+
 ## Specifying multiple patterns
 
 Multiple patterns can be specified when filtering the dependency tree by separating the patterns with commas. For example, to exclude Maven and Plexus dependencies from the tree, we can execute the following:
@@ -74,8 +77,12 @@ mvn dependency:tree -Dexcludes=org.apache.maven*,org.codehaus.plexus
 
 ## Including and excluding dependencies from the tree
 
-Both include and exclude patterns and be specified together to filter the dependency tree. For example, to locate all non-snapshot Plexus dependencies in the tree, we can execute the following:
+Both include and exclude patterns can be specified together to filter the dependency tree. For example, to locate all non-snapshot Plexus dependencies in the tree, we can execute the following:
 
 ```shell
 mvn dependency:tree -Dincludes=org.codehaus.plexus -Dexcludes=:::*-SNAPSHOT
 ```
+
+Excludes are applied first and take precedence over includes. Includes then select matching dependencies from the
+remaining tree and retain the paths leading to those dependencies. An include therefore cannot restore a dependency
+beneath an excluded subtree.

--- a/src/test/java/org/apache/maven/plugins/dependency/tree/PruningDependencyNodeVisitorTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/tree/PruningDependencyNodeVisitorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.dependency.tree;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.shared.dependency.graph.DependencyNode;
+import org.apache.maven.shared.dependency.graph.filter.DependencyNodeFilter;
+import org.apache.maven.shared.dependency.graph.internal.DefaultDependencyNode;
+import org.apache.maven.shared.dependency.graph.traversal.CollectingDependencyNodeVisitor;
+import org.apache.maven.shared.dependency.graph.traversal.DependencyNodeVisitor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+class PruningDependencyNodeVisitorTest {
+    @Test
+    void evaluatesFilterOnlyWhenStartingNodeVisit() {
+        DefaultDependencyNode root = newNode(null);
+        root.setChildren(Collections.emptyList());
+        AtomicInteger filterInvocations = new AtomicInteger();
+        AtomicInteger endVisits = new AtomicInteger();
+        DependencyNodeVisitor visitor = new DependencyNodeVisitor() {
+            @Override
+            public boolean visit(DependencyNode node) {
+                return true;
+            }
+
+            @Override
+            public boolean endVisit(DependencyNode node) {
+                endVisits.incrementAndGet();
+                return true;
+            }
+        };
+
+        root.accept(new PruningDependencyNodeVisitor(visitor, node -> filterInvocations.incrementAndGet() == 1));
+
+        assertEquals(1, filterInvocations.get());
+        assertEquals(1, endVisits.get());
+    }
+
+    @Test
+    void prunesRejectedSubtreeAndContinuesWithSiblings() {
+        DefaultDependencyNode root = newNode(null);
+        DefaultDependencyNode rejected = newNode(root);
+        DefaultDependencyNode rejectedChild = newNode(rejected);
+        DefaultDependencyNode sibling = newNode(root);
+
+        root.setChildren(Arrays.asList(rejected, sibling));
+        rejected.setChildren(Collections.singletonList(rejectedChild));
+        rejectedChild.setChildren(Collections.emptyList());
+        sibling.setChildren(Collections.emptyList());
+
+        CollectingDependencyNodeVisitor collectingVisitor = new CollectingDependencyNodeVisitor();
+        DependencyNodeFilter filter = node -> node != rejected;
+
+        root.accept(new PruningDependencyNodeVisitor(collectingVisitor, filter));
+
+        assertEquals(Arrays.asList(root, sibling), collectingVisitor.getNodes());
+    }
+
+    private DefaultDependencyNode newNode(DependencyNode parent) {
+        return new DefaultDependencyNode(parent, mock(Artifact.class), null, null, null);
+    }
+}


### PR DESCRIPTION
## Summary

- make `dependency:tree` prune a dependency matching `excludes` together with its complete subtree
- apply exclusions before includes, so an include cannot restore a node beneath an excluded subtree
- retain ancestor paths for included nodes that remain after exclusion pruning
- document the behavior and add unit and integration coverage for pruning, sibling traversal, and combined filters

## Root cause

The existing implementation combined `includes` and `excludes` into one node filter and applied it through `FilteringDependencyNodeVisitor`. A rejected node was omitted from the serialized output, but its children were still traversed. When includes were also present, the ancestor-or-self pass could restore paths through nodes that had matched an exclude pattern.

This change introduces a pruning visitor. A rejected node returns `false` from `visit`, preventing traversal of its children, while its matching `endVisit` returns `true` so traversal continues with the node's next sibling. The visitor remembers the acceptance decision made at the start of the visit so the delegate receives balanced `visit`/`endVisit` callbacks without evaluating the filter twice.

## Semantics and compatibility

This intentionally changes the output-filtering semantics of `dependency:tree`:

- `excludes` is a structural pruning operation. A matching node and every node below it are absent from the serialized tree.
- `includes` is a positive filter over the tree that remains after pruning. It selects matching dependencies and retains the ancestor paths needed to reach them.
- exclusions take precedence; includes cannot override them.
- this affects only serialization of the dependency tree and does not change dependency collection or resolution.

As discussed in #1334, the current parameter names do not describe these distinct roles especially well. Names such as `filter` for the path-preserving positive selection and `exclusions` for subtree pruning would communicate the behavior more clearly. This PR retains the established `includes` and `excludes` names for CLI and plugin-configuration compatibility. Introducing aliases, deprecating the existing names, or renaming them should be considered separately as an API migration.

## Validation

- `mvn spotless:apply`
- Maven 3: `mvn verify` — 412 tests passed, 1 skipped
- Maven 3: `mvn -Prun-its verify` — 99 integration-test projects passed
- Maven 4: `mvn verify` — 412 tests passed, 1 skipped
- Maven 4: `mvn -Prun-its verify` — 98 integration-test projects passed, 1 skipped due to its Maven-version condition
- Spring Web Services 4.0.11 reproducer with the snapshot plugin, both normal and `-Dverbose=true`: excluding `org.glassfish.jaxb:jaxb-runtime` also removes `jaxb-core`, `txw2`, and `istack-commons-runtime`

Fixes #1427

Fixes #1334

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
