### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/src/site/markdown/examples/copying-artifacts.md.vm
+++ b/src/site/markdown/examples/copying-artifacts.md.vm
@@ -1,3 +1,12 @@
+---
+title: Copying specific artifacts
+author: 
+  - Allan Ramirez
+  - Brian Fox
+  - Stephen Connolly
+date: 2011-07-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/copying-project-dependencies.md.vm
+++ b/src/site/markdown/examples/copying-project-dependencies.md.vm
@@ -1,3 +1,11 @@
+---
+title: Copying project dependencies
+author: 
+  - Allan Ramirez
+  - Brian Fox
+date: 2006-11-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/exclude-dependencies-from-dependency-analysis.md.vm
+++ b/src/site/markdown/examples/exclude-dependencies-from-dependency-analysis.md.vm
@@ -1,3 +1,10 @@
+---
+title: Exclude dependencies from dependency analysis
+author: 
+  - Henning Schmiedehausen
+date: 2015-01-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/failing-the-build-on-dependency-analysis-warnings.md.vm
+++ b/src/site/markdown/examples/failing-the-build-on-dependency-analysis-warnings.md.vm
@@ -1,3 +1,10 @@
+---
+title: Failing the build on dependency analysis warnings
+author: 
+  - Mark Hobson
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/filtering-the-dependency-tree.md
+++ b/src/site/markdown/examples/filtering-the-dependency-tree.md
@@ -1,3 +1,10 @@
+---
+title: Filtering the dependency tree
+author: 
+  - Mark Hobson
+date: 2007-09-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/managing-dependencies.md.vm
+++ b/src/site/markdown/examples/managing-dependencies.md.vm
@@ -1,3 +1,10 @@
+---
+title: Managing Dependencies
+author: 
+  - Bruno Borges
+date: 2025-06-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/purging-local-repository.md.vm
+++ b/src/site/markdown/examples/purging-local-repository.md.vm
@@ -1,3 +1,11 @@
+---
+title: Purging project dependencies
+author: 
+  - Nicolas Cazottes
+  - Paul Gier
+date: 2012-10-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/render-dependencies.md.vm
+++ b/src/site/markdown/examples/render-dependencies.md.vm
@@ -1,3 +1,12 @@
+---
+title: Render a Velocity template
+author: 
+  - Allan Ramirez
+  - Brian Fox
+  - Stephen Connolly
+date: 2025-09-17
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/tree-mojo.md
+++ b/src/site/markdown/examples/tree-mojo.md
@@ -1,3 +1,10 @@
+---
+title: Dependency Tree Output Formats
+author: 
+  - Tayebwa Noah
+date: 2025-06-04
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/unpacking-artifacts.md.vm
+++ b/src/site/markdown/examples/unpacking-artifacts.md.vm
@@ -1,3 +1,11 @@
+---
+title: Unpacking specific artifacts
+author: 
+  - Allan Ramirez
+  - Brian Fox
+date: 2006-11-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/unpacking-filemapper.md.vm
+++ b/src/site/markdown/examples/unpacking-filemapper.md.vm
@@ -1,3 +1,10 @@
+---
+title: Rewriting target path and file name
+author: 
+  - Markus KARG
+date: 2018-09-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/unpacking-project-dependencies.md.vm
+++ b/src/site/markdown/examples/unpacking-project-dependencies.md.vm
@@ -1,3 +1,11 @@
+---
+title: Unpacking project dependencies
+author: 
+  - Allan Ramirez
+  - Brian Fox
+date: 2006-11-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/examples/using-dependencies-sources.md.vm
+++ b/src/site/markdown/examples/using-dependencies-sources.md.vm
@@ -1,3 +1,10 @@
+---
+title: Unpacking project dependencies
+author: 
+  - Carlos Sanchez
+date: 2007-10-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,11 @@
+---
+title: Introduction
+author: 
+  - Allan Ramirez
+  - Brian Fox
+date: 2014-08-07
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/usage.md.vm
+++ b/src/site/markdown/usage.md.vm
@@ -1,3 +1,11 @@
+---
+title: Usage
+author: 
+  - Allan Ramirez
+  - Brian Fox
+date: 2010-05-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.