### PR TITLE
[MDEP-858] Get rid of maven-artifact-transfer and maven-compat from the get goal

### DIFF
--- a/src/it/projects/get-remote-repositories-pom-config/invoker.properties
+++ b/src/it/projects/get-remote-repositories-pom-config/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+invoker.goals = clean process-sources

--- a/src/it/projects/get-remote-repositories-pom-config/pom.xml
+++ b/src/it/projects/get-remote-repositories-pom-config/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+  
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>get-remote-repositories-pom-config</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Tests that a comma-separated remoteRepositories value written as POM element text, the form that
+    worked when the parameter was a plain String, is still accepted now that it is a List.
+  </description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>@project.version@</version>
+        <executions>
+          <execution>
+            <id>get-with-comma-separated-repositories</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>get</goal>
+            </goals>
+            <configuration>
+              <artifact>org.apache.maven.its.dependency:get-artifact:1.0</artifact>
+              <remoteRepositories>repo1::default::https://repo1.invalid/maven2,repo2::https://repo2.invalid/maven2</remoteRepositories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/projects/get-remote-repositories-pom-config/setup.bsh
+++ b/src/it/projects/get-remote-repositories-pom-config/setup.bsh
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+import org.codehaus.plexus.util.*;
+
+String[] foldersToDelete = {
+    "org/apache/maven/its/dependency/get-artifact",
+    "org/apache/maven/its/dependency/get-artifact-transitive"
+};
+
+try
+{
+    for ( String folderToDelete : foldersToDelete )
+    {
+        FileUtils.deleteDirectory( new File( localRepositoryPath, folderToDelete ) );
+    }
+}
+catch ( IOException e )
+{
+    e.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/projects/get-remote-repositories-pom-config/verify.bsh
+++ b/src/it/projects/get-remote-repositories-pom-config/verify.bsh
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+String[] expectedFiles = {
+    "org/apache/maven/its/dependency/get-artifact/1.0/get-artifact-1.0.jar",
+    "org/apache/maven/its/dependency/get-artifact/1.0/get-artifact-1.0.pom",
+    "org/apache/maven/its/dependency/get-artifact-transitive/1.0/get-artifact-transitive-1.0.jar",
+    "org/apache/maven/its/dependency/get-artifact-transitive/1.0/get-artifact-transitive-1.0.pom"
+};
+
+for ( String expectedFile : expectedFiles )
+{
+    File file = new File( localRepositoryPath, expectedFile );
+    if ( !file.isFile() )
+    {
+        throw new Exception( "Missing file " + file );
+    }
+}
+
+return true;

--- a/src/it/projects/get-remote-repositories/invoker.properties
+++ b/src/it/projects/get-remote-repositories/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+invoker.goals = ${project.groupId}:${project.artifactId}:${project.version}:get

--- a/src/it/projects/get-remote-repositories/pom.xml
+++ b/src/it/projects/get-remote-repositories/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+  
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  
+  <groupId>org.apache.maven.plugins.dependency.its</groupId>
+  <artifactId>get-remote-repositories</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <description>
+    Tests that a comma-separated remoteRepositories value is bound as one element per repository.
+  </description>
+
+</project>

--- a/src/it/projects/get-remote-repositories/setup.bsh
+++ b/src/it/projects/get-remote-repositories/setup.bsh
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+import org.codehaus.plexus.util.*;
+
+String[] foldersToDelete = {
+    "org/apache/maven/its/dependency/get-artifact",
+    "org/apache/maven/its/dependency/get-artifact-transitive"
+};
+
+try
+{
+    for ( String folderToDelete : foldersToDelete )
+    {
+        FileUtils.deleteDirectory( new File( localRepositoryPath, folderToDelete ) );
+    }
+}
+catch ( IOException e )
+{
+    e.printStackTrace();
+    return false;
+}
+
+return true;

--- a/src/it/projects/get-remote-repositories/test.properties
+++ b/src/it/projects/get-remote-repositories/test.properties
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+# Two repositories in one comma-separated value, exercising both accepted forms
+# (id::layout::url and id::url). The mrm mirror in src/it/mrm/settings.xml matches
+# "*", so both are mirrored to the mock repository and the .invalid hosts are never
+# contacted. If the value were bound as a SINGLE list element still containing the
+# comma, splitting it on "::" would yield five tokens and the goal would fail with
+# "Invalid repository" -- so a passing build proves the comma-separated form still
+# arrives as one element per repository.
+artifact=org.apache.maven.its.dependency:get-artifact:1.0
+remoteRepositories=repo1::default::https://repo1.invalid/maven2,repo2::https://repo2.invalid/maven2

--- a/src/it/projects/get-remote-repositories/verify.bsh
+++ b/src/it/projects/get-remote-repositories/verify.bsh
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+
+String[] expectedFiles = {
+    "org/apache/maven/its/dependency/get-artifact/1.0/get-artifact-1.0.jar",
+    "org/apache/maven/its/dependency/get-artifact/1.0/get-artifact-1.0.pom",
+    "org/apache/maven/its/dependency/get-artifact-transitive/1.0/get-artifact-transitive-1.0.jar",
+    "org/apache/maven/its/dependency/get-artifact-transitive/1.0/get-artifact-transitive-1.0.pom"
+};
+
+for ( String expectedFile : expectedFiles )
+{
+    File file = new File( localRepositoryPath, expectedFile );
+    if ( !file.isFile() )
+    {
+        throw new Exception( "Missing file " + file );
+    }
+}
+
+return true;

--- a/src/main/java/org/apache/maven/plugins/dependency/GetMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/GetMojo.java
@@ -20,36 +20,20 @@ package org.apache.maven.plugins.dependency;
 
 import javax.inject.Inject;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import org.apache.maven.artifact.handler.ArtifactHandler;
-import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
-import org.apache.maven.artifact.repository.MavenArtifactRepository;
-import org.apache.maven.artifact.repository.layout.ArtifactRepositoryLayout;
-import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.RepositorySystem;
-import org.apache.maven.settings.Settings;
-import org.apache.maven.shared.transfer.artifact.ArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
-import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
-import org.apache.maven.shared.transfer.dependencies.DefaultDependableCoordinate;
-import org.apache.maven.shared.transfer.dependencies.DependableCoordinate;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolver;
-import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
+import org.apache.maven.plugins.dependency.utils.ParamArtifact;
+import org.apache.maven.plugins.dependency.utils.ResolverUtil;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.ArtifactDescriptorException;
+import org.eclipse.aether.resolution.ArtifactResolutionException;
+import org.eclipse.aether.resolution.DependencyResolutionException;
 
 /**
  * Resolves a single artifact, eventually transitively, from the specified remote repositories. Caveat: will always
@@ -57,43 +41,19 @@ import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverE
  */
 @Mojo(name = "get", requiresProject = false, threadSafe = true)
 public class GetMojo extends AbstractMojo {
-    private static final Pattern ALT_REPO_SYNTAX_PATTERN = Pattern.compile("(.+)::(.*)::(.+)");
 
-    private final MavenSession session;
+    private final ResolverUtil resolverUtil;
 
-    private final ArtifactResolver artifactResolver;
-
-    private final DependencyResolver dependencyResolver;
-
-    private final ArtifactHandlerManager artifactHandlerManager;
+    private final ParamArtifact paramArtifact = new ParamArtifact();
 
     /**
-     * Map that contains the layouts.
-     */
-    private final Map<String, ArtifactRepositoryLayout> repositoryLayouts;
-
-    /**
-     * The repository system.
-     */
-    private final RepositorySystem repositorySystem;
-
-    private final DefaultDependableCoordinate coordinate = new DefaultDependableCoordinate();
-
-    /**
-     * Repositories in the format id::[layout]::url or just url, separated by comma. i.e.
-     * central::default::https://repo.maven.apache.org/maven2,myrepo::::https://repo.acme.com,https://repo.acme2.com.
+     * Repositories in the format {@code id::[layout::]url} or just URLs, separated by comma. That is,
+     * <code>
+     * central::default::https://repo.maven.apache.org/maven2,myrepo::https://repo.acme.com,https://repo.acme2.com
+     * </code>
      */
     @Parameter(property = "remoteRepositories")
-    private String remoteRepositories;
-
-    /**
-     * A string of the form groupId:artifactId:version[:packaging[:classifier]].
-     */
-    @Parameter(property = "artifact")
-    private String artifact;
-
-    @Parameter(defaultValue = "${project.remoteArtifactRepositories}", readonly = true, required = true)
-    private List<ArtifactRepository> pomRemoteRepositories;
+    private List<String> remoteRepositories;
 
     /**
      * Resolve transitively, retrieving the specified artifact and all of its dependencies.
@@ -110,19 +70,8 @@ public class GetMojo extends AbstractMojo {
     private boolean skip;
 
     @Inject
-    public GetMojo(
-            MavenSession session,
-            ArtifactResolver artifactResolver,
-            DependencyResolver dependencyResolver,
-            ArtifactHandlerManager artifactHandlerManager,
-            Map<String, ArtifactRepositoryLayout> repositoryLayouts,
-            RepositorySystem repositorySystem) {
-        this.session = session;
-        this.artifactResolver = artifactResolver;
-        this.dependencyResolver = dependencyResolver;
-        this.artifactHandlerManager = artifactHandlerManager;
-        this.repositoryLayouts = repositoryLayouts;
-        this.repositorySystem = repositorySystem;
+    public GetMojo(ResolverUtil resolverUtil) {
+        this.resolverUtil = resolverUtil;
     }
 
     @Override
@@ -132,111 +81,32 @@ public class GetMojo extends AbstractMojo {
             return;
         }
 
-        if (coordinate.getArtifactId() == null && artifact == null) {
-            throw new MojoFailureException("You must specify an artifact, "
-                    + "e.g. -Dartifact=org.apache.maven.plugins:maven-downloader-plugin:1.0");
-        }
-        if (artifact != null) {
-            String[] tokens = artifact.split(":");
-            if (tokens.length < 3 || tokens.length > 5) {
-                throw new MojoFailureException("Invalid artifact, you must specify "
-                        + "groupId:artifactId:version[:packaging[:classifier]] " + artifact);
-            }
-            coordinate.setGroupId(tokens[0]);
-            coordinate.setArtifactId(tokens[1]);
-            coordinate.setVersion(tokens[2]);
-            if (tokens.length >= 4) {
-                coordinate.setType(tokens[3]);
-            }
-            if (tokens.length == 5) {
-                coordinate.setClassifier(tokens[4]);
-            }
+        if (!paramArtifact.isDataSet()) {
+            throw new MojoFailureException("You must specify an artifact OR GAV separately, "
+                    + "e.g. -Dartifact=org.apache.maven.plugins:maven-downloader-plugin:1.0 OR "
+                    + "-DgroupId=org.apache.maven.plugins -DartifactId=maven-downloader-plugin -Dversion=1.0");
         }
 
-        ArtifactRepositoryPolicy always = new ArtifactRepositoryPolicy(
-                true, ArtifactRepositoryPolicy.UPDATE_POLICY_ALWAYS, ArtifactRepositoryPolicy.CHECKSUM_POLICY_WARN);
-
-        List<ArtifactRepository> repoList = new ArrayList<>();
-
-        if (pomRemoteRepositories != null) {
-            repoList.addAll(pomRemoteRepositories);
-        }
-
-        if (remoteRepositories != null) {
-            // Use the same format as in the deploy plugin id::layout::url
-            String[] repos = remoteRepositories.split(",");
-            for (String repo : repos) {
-                repoList.add(parseRepository(repo, always));
-            }
+        Artifact artifact;
+        List<RemoteRepository> repositories;
+        try {
+            artifact = resolverUtil.createArtifactFromParams(paramArtifact);
+            repositories = resolverUtil.remoteRepositories(remoteRepositories);
+        } catch (IllegalArgumentException e) {
+            throw new MojoFailureException(e.getMessage(), e);
         }
 
         try {
-            ProjectBuildingRequest buildingRequest =
-                    new DefaultProjectBuildingRequest(session.getProjectBuildingRequest());
-
-            Settings settings = session.getSettings();
-            repositorySystem.injectMirror(repoList, settings.getMirrors());
-            repositorySystem.injectProxy(repoList, settings.getProxies());
-            repositorySystem.injectAuthentication(repoList, settings.getServers());
-
-            buildingRequest.setRemoteRepositories(repoList);
-
             if (transitive) {
-                getLog().info("Resolving " + coordinate + " with transitive dependencies");
-                dependencyResolver.resolveDependencies(buildingRequest, coordinate, null);
+                getLog().info("Resolving " + artifact + " with transitive dependencies");
+                resolverUtil.resolveDependencies(artifact, repositories);
             } else {
-                getLog().info("Resolving " + coordinate);
-                artifactResolver.resolveArtifact(buildingRequest, toArtifactCoordinate(coordinate));
+                getLog().info("Resolving " + artifact);
+                resolverUtil.resolveArtifact(artifact, repositories);
             }
-        } catch (ArtifactResolverException | DependencyResolverException e) {
+        } catch (ArtifactResolutionException | ArtifactDescriptorException | DependencyResolutionException e) {
             throw new MojoExecutionException("Couldn't download artifact: " + e.getMessage(), e);
         }
-    }
-
-    private ArtifactCoordinate toArtifactCoordinate(DependableCoordinate dependableCoordinate) {
-        ArtifactHandler artifactHandler = artifactHandlerManager.getArtifactHandler(dependableCoordinate.getType());
-        DefaultArtifactCoordinate artifactCoordinate = new DefaultArtifactCoordinate();
-        artifactCoordinate.setGroupId(dependableCoordinate.getGroupId());
-        artifactCoordinate.setArtifactId(dependableCoordinate.getArtifactId());
-        artifactCoordinate.setVersion(dependableCoordinate.getVersion());
-        artifactCoordinate.setClassifier(dependableCoordinate.getClassifier());
-        artifactCoordinate.setExtension(artifactHandler.getExtension());
-        return artifactCoordinate;
-    }
-
-    ArtifactRepository parseRepository(String repo, ArtifactRepositoryPolicy policy) throws MojoFailureException {
-        // if it's a simple url
-        String id = "temp";
-        ArtifactRepositoryLayout layout = getLayout("default");
-        String url = repo;
-
-        // if it's an extended repo URL of the form id::layout::url
-        if (repo.contains("::")) {
-            Matcher matcher = ALT_REPO_SYNTAX_PATTERN.matcher(repo);
-            if (!matcher.matches()) {
-                throw new MojoFailureException(
-                        repo,
-                        "Invalid syntax for repository: " + repo,
-                        "Invalid syntax for repository. Use \"id::layout::url\" or \"URL\".");
-            }
-
-            id = matcher.group(1).trim();
-            if (matcher.group(2) != null && !matcher.group(2).isEmpty()) {
-                layout = getLayout(matcher.group(2).trim());
-            }
-            url = matcher.group(3).trim();
-        }
-        return new MavenArtifactRepository(id, url, layout, policy, policy);
-    }
-
-    private ArtifactRepositoryLayout getLayout(String id) throws MojoFailureException {
-        ArtifactRepositoryLayout layout = repositoryLayouts.get(id);
-
-        if (layout == null) {
-            throw new MojoFailureException(id, "Invalid repository layout", "Invalid repository layout: " + id);
-        }
-
-        return layout;
     }
 
     /**
@@ -247,53 +117,63 @@ public class GetMojo extends AbstractMojo {
     }
 
     /**
-     * The groupId of the artifact to resolve. Ignored if {@link #artifact} is used.
+     * The groupId of the artifact to resolve. Ignored if {@code artifact} is used.
      *
      * @param groupId the groupId
      */
     @Parameter(property = "groupId")
     public void setGroupId(String groupId) {
-        this.coordinate.setGroupId(groupId);
+        paramArtifact.setGroupId(groupId);
     }
 
     /**
-     * The artifactId of the artifact to resolve. Ignored if {@link #artifact} is used.
+     * The artifactId of the artifact to resolve. Ignored if {@code artifact} is used.
      *
      * @param artifactId the artifactId
      */
     @Parameter(property = "artifactId")
     public void setArtifactId(String artifactId) {
-        this.coordinate.setArtifactId(artifactId);
+        paramArtifact.setArtifactId(artifactId);
     }
 
     /**
-     * The version of the artifact to resolve. Ignored if {@link #artifact} is used.
+     * The version of the artifact to resolve. Ignored if {@code artifact} is used.
      *
      * @param version the version
      */
     @Parameter(property = "version")
     public void setVersion(String version) {
-        this.coordinate.setVersion(version);
+        paramArtifact.setVersion(version);
     }
 
     /**
-     * The classifier of the artifact to resolve. Ignored if {@link #artifact} is used.
+     * The classifier of the artifact to resolve. Ignored if {@code artifact} is used.
      *
      * @param classifier the classifier to be used
      * @since 2.3
      */
     @Parameter(property = "classifier")
     public void setClassifier(String classifier) {
-        this.coordinate.setClassifier(classifier);
+        paramArtifact.setClassifier(classifier);
     }
 
     /**
-     * The packaging of the artifact to resolve. Ignored if {@link #artifact} is used.
+     * The packaging of the artifact to resolve. Ignored if {@code artifact} is used.
      *
      * @param type packaging
      */
     @Parameter(property = "packaging", defaultValue = "jar")
     public void setPackaging(String type) {
-        this.coordinate.setType(type);
+        paramArtifact.setPackaging(type);
+    }
+
+    /**
+     * A string of the form groupId:artifactId:version[:packaging[:classifier]].
+     *
+     * @param artifact the artifact coordinates
+     */
+    @Parameter(property = "artifact")
+    public void setArtifact(String artifact) {
+        paramArtifact.setArtifact(artifact);
     }
 }

--- a/src/main/java/org/apache/maven/plugins/dependency/GetMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/GetMojo.java
@@ -51,6 +51,16 @@ public class GetMojo extends AbstractMojo {
      * <code>
      * central::default::https://repo.maven.apache.org/maven2,myrepo::https://repo.acme.com,https://repo.acme2.com
      * </code>
+     * <p>
+     * The comma-separated form works both on the command line and as the text of a single
+     * <code>&lt;remoteRepositories&gt;</code> element. In a POM the repositories may also be listed one per
+     * element:
+     * <pre>
+     * &lt;remoteRepositories&gt;
+     *   &lt;remoteRepository&gt;central::default::https://repo.maven.apache.org/maven2&lt;/remoteRepository&gt;
+     *   &lt;remoteRepository&gt;https://repo.acme.com&lt;/remoteRepository&gt;
+     * &lt;/remoteRepositories&gt;
+     * </pre>
      */
     @Parameter(property = "remoteRepositories")
     private List<String> remoteRepositories;

--- a/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/utils/ResolverUtil.java
@@ -290,16 +290,16 @@ public class ResolverUtil {
         String url;
         switch (items.length) {
             case 3:
-                id = items[0];
-                type = items[1];
-                url = items[2];
+                id = items[0].trim();
+                type = items[1].trim();
+                url = items[2].trim();
                 break;
             case 2:
-                id = items[0];
-                url = items[1];
+                id = items[0].trim();
+                url = items[1].trim();
                 break;
             case 1:
-                url = items[0];
+                url = items[0].trim();
                 break;
             default:
                 throw new IllegalArgumentException("Invalid repository: " + repository);
@@ -352,8 +352,9 @@ public class ResolverUtil {
     private Artifact createArtifactFromString(String artifact) {
         // groupId:artifactId:version[:packaging[:classifier]].
         String[] items = artifact.split(":");
-        if (items.length < 3) {
-            throw new IllegalArgumentException("Invalid artifact format: " + artifact);
+        if (items.length < 3 || items.length > 5) {
+            throw new IllegalArgumentException("Invalid artifact format: " + artifact
+                    + ", expected groupId:artifactId:version[:packaging[:classifier]]");
         }
 
         ArtifactType artifactType = getArtifactType(items.length > 3 ? items[3] : null);

--- a/src/test/java/org/apache/maven/plugins/dependency/TestGetMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/TestGetMojo.java
@@ -23,25 +23,25 @@ import javax.inject.Inject;
 import java.net.InetAddress;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 
 import org.apache.maven.api.plugin.testing.Basedir;
 import org.apache.maven.api.plugin.testing.InjectMojo;
 import org.apache.maven.api.plugin.testing.MojoParameter;
 import org.apache.maven.api.plugin.testing.MojoTest;
-import org.apache.maven.artifact.repository.ArtifactRepository;
-import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
-import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.settings.Proxy;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.repository.LocalRepository;
+import org.eclipse.aether.util.repository.AuthenticationBuilder;
+import org.eclipse.aether.util.repository.DefaultAuthenticationSelector;
+import org.eclipse.aether.util.repository.DefaultProxySelector;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
@@ -57,10 +57,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.maven.api.plugin.testing.MojoExtension.getTestPath;
 import static org.apache.maven.api.plugin.testing.MojoExtension.setVariableValueToObject;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.when;
 
 @MojoTest(realRepositorySession = true)
@@ -91,6 +89,57 @@ class TestGetMojo {
     }
 
     /**
+     * Mirrors the {@code <server>} and {@code <proxy>} entries of the session settings into the repository session,
+     * the way {@code DefaultRepositorySystemSessionFactory} does when Maven builds that session for real. The
+     * repositories named by the {@code remoteRepositories} parameter get their credentials and proxies from those
+     * selectors, by way of {@code RepositorySystem.newResolutionRepositories}, and the test harness has already
+     * created the repository session by the time {@link #setUp()} declares any of this.
+     * <p>
+     * The local repository is swapped for an empty one at the same time, so that the tests below depend on the
+     * transfer actually happening rather than on what an earlier test left in the shared local repository.
+     */
+    private void applySettingsToRepositorySession() {
+        Settings settings = session.getSettings();
+
+        DefaultAuthenticationSelector authenticationSelector = new DefaultAuthenticationSelector();
+        for (Server server : settings.getServers()) {
+            authenticationSelector.add(
+                    server.getId(),
+                    new AuthenticationBuilder()
+                            .addUsername(server.getUsername())
+                            .addPassword(server.getPassword())
+                            .addPrivateKey(server.getPrivateKey(), server.getPassphrase())
+                            .build());
+        }
+
+        DefaultProxySelector proxySelector = new DefaultProxySelector();
+        for (Proxy proxy : settings.getProxies()) {
+            if (!proxy.isActive()) {
+                // Maven filters the inactive ones out before they ever reach the selector
+                continue;
+            }
+            proxySelector.add(
+                    new org.eclipse.aether.repository.Proxy(
+                            proxy.getProtocol(),
+                            proxy.getHost(),
+                            proxy.getPort(),
+                            new AuthenticationBuilder()
+                                    .addUsername(proxy.getUsername())
+                                    .addPassword(proxy.getPassword())
+                                    .build()),
+                    proxy.getNonProxyHosts());
+        }
+
+        DefaultRepositorySystemSession repositorySession =
+                new DefaultRepositorySystemSession(session.getRepositorySession());
+        repositorySession.setAuthenticationSelector(authenticationSelector);
+        repositorySession.setProxySelector(proxySelector);
+        repositorySession.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(
+                repositorySession, new LocalRepository(isolatedLocalRepository.toFile())));
+        when(session.getRepositorySession()).thenReturn(repositorySession);
+    }
+
+    /**
      * Test transitive parameter
      *
      * @throws Exception in case of errors
@@ -99,10 +148,6 @@ class TestGetMojo {
     @InjectMojo(goal = "get")
     @MojoParameter(name = "transitive", value = "false")
     void testTransitive(GetMojo mojo) throws Exception {
-        DefaultProjectBuildingRequest pbr = new DefaultProjectBuildingRequest();
-        pbr.setRepositorySession(session.getRepositorySession());
-        when(session.getProjectBuildingRequest()).thenReturn(pbr);
-
         mojo.setGroupId("org.apache.maven");
         mojo.setArtifactId("maven-model");
         mojo.setVersion("2.0.9");
@@ -119,13 +164,10 @@ class TestGetMojo {
     @InjectMojo(goal = "get")
     @MojoParameter(
             name = "remoteRepositories",
-            value =
-                    "central::default::https://repo.maven.apache.org/maven2,central::::https://repo.maven.apache.org/maven2,https://repo.maven.apache.org/maven2")
+            value = "central::default::https://repo.maven.apache.org/maven2,"
+                    + "central::::https://repo.maven.apache.org/maven2,"
+                    + "https://repo.maven.apache.org/maven2")
     void testRemoteRepositories(GetMojo mojo) throws Exception {
-        DefaultProjectBuildingRequest pbr = new DefaultProjectBuildingRequest();
-        pbr.setRepositorySession(session.getRepositorySession());
-        when(session.getProjectBuildingRequest()).thenReturn(pbr);
-
         mojo.setGroupId("org.apache.maven");
         mojo.setArtifactId("maven-model");
         mojo.setVersion("2.0.9");
@@ -134,7 +176,28 @@ class TestGetMojo {
     }
 
     /**
-     * Test remote repositories parameter with basic authentication.
+     * Test that neither an artifact nor a complete GAV is a failure rather than an attempted resolution.
+     */
+    @Test
+    @InjectMojo(goal = "get")
+    void testMissingArtifact(GetMojo mojo) {
+        assertThrows(MojoFailureException.class, mojo::execute);
+    }
+
+    /**
+     * Test that a malformed <code>artifact</code> parameter is reported as a failure.
+     */
+    @Test
+    @InjectMojo(goal = "get")
+    @MojoParameter(name = "artifact", value = "org.apache.maven:maven-model")
+    void testInvalidArtifact(GetMojo mojo) {
+        assertThrows(MojoFailureException.class, mojo::execute);
+    }
+
+    /**
+     * Test remote repositories parameter with basic authentication
+     *
+     * @throws Exception in case of errors
      */
     @Test
     @InjectMojo(goal = "get")
@@ -143,9 +206,9 @@ class TestGetMojo {
         try {
             server.start();
 
-            setVariableValueToObject(mojo, "remoteRepositories", "myserver::default::" + serverUrl(server));
+            setRemoteRepositories(mojo, "myserver::default::" + serverUrl(server));
 
-            useIsolatedLocalRepository();
+            applySettingsToRepositorySession();
 
             mojo.setGroupId("test");
             mojo.setArtifactId("test");
@@ -161,6 +224,8 @@ class TestGetMojo {
      * Test that an active proxy from the settings is applied to the repositories given by the
      * <code>remoteRepositories</code> parameter. The proxy points at a host that cannot resolve, so a successful
      * resolution would mean the proxy was never applied.
+     *
+     * @throws Exception in case of errors
      */
     @Test
     @InjectMojo(goal = "get")
@@ -169,10 +234,10 @@ class TestGetMojo {
         try {
             server.start();
 
-            setVariableValueToObject(mojo, "remoteRepositories", "myserver::default::" + serverUrl(server));
+            setRemoteRepositories(mojo, "myserver::default::" + serverUrl(server));
 
             session.getSettings().addProxy(createProxy(null));
-            useIsolatedLocalRepository();
+            applySettingsToRepositorySession();
 
             mojo.setGroupId("test");
             mojo.setArtifactId("test");
@@ -194,6 +259,8 @@ class TestGetMojo {
      * This one asserts a success, so on its own it cannot tell "nonProxyHosts was honoured" apart from "proxies are
      * not applied at all". It is only meaningful together with {@link #testRemoteRepositoriesProxy(GetMojo)}, which
      * fails in that second case -- do not delete one and keep the other.
+     *
+     * @throws Exception in case of errors
      */
     @Test
     @InjectMojo(goal = "get")
@@ -203,10 +270,10 @@ class TestGetMojo {
             server.start();
             String url = serverUrl(server);
 
-            setVariableValueToObject(mojo, "remoteRepositories", "myserver::default::" + url);
+            setRemoteRepositories(mojo, "myserver::default::" + url);
 
             session.getSettings().addProxy(createProxy(URI.create(url).getHost()));
-            useIsolatedLocalRepository();
+            applySettingsToRepositorySession();
 
             mojo.setGroupId("test");
             mojo.setArtifactId("test");
@@ -218,20 +285,8 @@ class TestGetMojo {
         }
     }
 
-    /**
-     * Points the mojo at an empty local repository, so that the tests above depend on the transfer actually
-     * happening rather than on what an earlier run left behind in the shared one.
-     */
-    private void useIsolatedLocalRepository() {
-        DefaultRepositorySystemSession repositorySession =
-                new DefaultRepositorySystemSession(session.getRepositorySession());
-        repositorySession.setLocalRepositoryManager(repositorySystem.newLocalRepositoryManager(
-                repositorySession, new LocalRepository(isolatedLocalRepository.toFile())));
-        when(session.getRepositorySession()).thenReturn(repositorySession);
-
-        DefaultProjectBuildingRequest pbr = new DefaultProjectBuildingRequest();
-        pbr.setRepositorySession(repositorySession);
-        when(session.getProjectBuildingRequest()).thenReturn(pbr);
+    private void setRemoteRepositories(GetMojo mojo, String... repositories) throws Exception {
+        setVariableValueToObject(mojo, "remoteRepositories", Arrays.asList(repositories));
     }
 
     /**
@@ -267,52 +322,6 @@ class TestGetMojo {
                 ? InetAddress.getLoopbackAddress().getHostName()
                 : serverConnector.getHost();
         return "http://" + host + ":" + serverConnector.getLocalPort() + "/maven";
-    }
-
-    /**
-     * Test parsing of the remote repositories parameter
-     *
-     * @throws Exception in case of errors
-     */
-    @Test
-    @InjectMojo(goal = "get")
-    void testParseRepository(GetMojo mojo) throws Exception {
-        ArtifactRepositoryPolicy policy = null;
-        ArtifactRepository repo =
-                mojo.parseRepository("central::default::https://repo.maven.apache.org/maven2", policy);
-        assertEquals("central", repo.getId());
-        assertEquals(DefaultRepositoryLayout.class, repo.getLayout().getClass());
-        assertEquals("https://repo.maven.apache.org/maven2", repo.getUrl());
-
-        try {
-            repo = mojo.parseRepository("central::legacy::https://repo.maven.apache.org/maven2", policy);
-            fail("Exception expected: legacy repository not supported anymore");
-        } catch (MojoFailureException e) {
-        }
-
-        repo = mojo.parseRepository("central::::https://repo.maven.apache.org/maven2", policy);
-        assertEquals("central", repo.getId());
-        assertEquals(DefaultRepositoryLayout.class, repo.getLayout().getClass());
-        assertEquals("https://repo.maven.apache.org/maven2", repo.getUrl());
-
-        repo = mojo.parseRepository("https://repo.maven.apache.org/maven2", policy);
-        assertEquals("temp", repo.getId());
-        assertEquals(DefaultRepositoryLayout.class, repo.getLayout().getClass());
-        assertEquals("https://repo.maven.apache.org/maven2", repo.getUrl());
-
-        try {
-            mojo.parseRepository("::::https://repo.maven.apache.org/maven2", policy);
-            fail("Exception expected");
-        } catch (MojoFailureException e) {
-            // expected
-        }
-
-        try {
-            mojo.parseRepository("central::https://repo.maven.apache.org/maven2", policy);
-            fail("Exception expected");
-        } catch (MojoFailureException e) {
-            // expected
-        }
     }
 
     private ContextHandler createContextHandler() {

--- a/src/test/java/org/apache/maven/plugins/dependency/TestGetMojo.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/TestGetMojo.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.apache.maven.api.plugin.testing.Basedir;
 import org.apache.maven.api.plugin.testing.InjectMojo;
@@ -56,7 +57,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import static org.apache.maven.api.plugin.testing.MojoExtension.getTestPath;
+import static org.apache.maven.api.plugin.testing.MojoExtension.getVariableValueFromObject;
 import static org.apache.maven.api.plugin.testing.MojoExtension.setVariableValueToObject;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
@@ -168,6 +171,16 @@ class TestGetMojo {
                     + "central::::https://repo.maven.apache.org/maven2,"
                     + "https://repo.maven.apache.org/maven2")
     void testRemoteRepositories(GetMojo mojo) throws Exception {
+        // the parameter is a List<String>, and a comma-separated value must arrive as one element per
+        // repository -- not as a single element still containing the commas
+        List<String> repositories = getVariableValueFromObject(mojo, "remoteRepositories");
+        assertEquals(
+                Arrays.asList(
+                        "central::default::https://repo.maven.apache.org/maven2",
+                        "central::::https://repo.maven.apache.org/maven2",
+                        "https://repo.maven.apache.org/maven2"),
+                repositories);
+
         mojo.setGroupId("org.apache.maven");
         mojo.setArtifactId("maven-model");
         mojo.setVersion("2.0.9");

--- a/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
+++ b/src/test/java/org/apache/maven/plugins/dependency/utils/ResolverUtilTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -70,7 +71,16 @@ class ResolverUtilTest {
                         "central::layout2::https://repo.maven.apache.org",
                         "central",
                         "layout2",
-                        "https://repo.maven.apache.org"));
+                        "https://repo.maven.apache.org"),
+                // surrounding whitespace is not part of the id, layout or url: a comma-separated
+                // list written with spaces after the commas must behave like one written without
+                of(
+                        " central :: default :: https://repo.maven.apache.org ",
+                        "central",
+                        "default",
+                        "https://repo.maven.apache.org"),
+                of(" central :: https://repo.maven.apache.org ", "central", "default", "https://repo.maven.apache.org"),
+                of(" https://repo.maven.apache.org ", "temp", "default", "https://repo.maven.apache.org"));
     }
 
     @ParameterizedTest
@@ -97,6 +107,17 @@ class ResolverUtilTest {
         assertThat(releasePolicy).isNotNull();
         assertThat(releasePolicy.getUpdatePolicy()).isEqualTo(RepositoryPolicy.UPDATE_POLICY_ALWAYS);
         assertThat(releasePolicy.getChecksumPolicy()).isEqualTo(RepositoryPolicy.CHECKSUM_POLICY_WARN);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"groupId:artifactId", "groupId:artifactId:version:packaging:classifier:extra"})
+    void createArtifactFromInvalidString(String artifact) {
+        ParamArtifact paramArtifact = new ParamArtifact();
+        paramArtifact.setArtifact(artifact);
+
+        assertThatCode(() -> resolverUtil.createArtifactFromParams(paramArtifact))
+                .isExactlyInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Invalid artifact format: " + artifact);
     }
 
     @Test


### PR DESCRIPTION
> **Stacked on #1678** — base is `agent/mdep-get-test-hardening`, so the diff here is just this goal's migration. #1678 must merge first; I'll retarget to `master` then. Followed by #1679 (drop `maven-compat`).

`dependency:get` was the last goal still resolving through `maven-artifact-transfer` and the Maven 3 repository model. It built `org.apache.maven.artifact.repository.ArtifactRepository` instances by hand and then asked the legacy `org.apache.maven.repository.RepositorySystem` to `injectMirror`, `injectProxy` and `injectAuthentication` into them.

It now goes through `ResolverUtil`, the way `list-classes` has since MDEP-924. `ResolverUtil.remoteRepositories()` parses the same `id::layout::url` syntax into Resolver's `RemoteRepository` and hands the result to `RepositorySystem.newResolutionRepositories()`, whose documented job is *"applying the session's authentication selector and similar network configuration to the given repository prototypes"* — the supported replacement for the three legacy inject calls, and the same selectors Resolver consults when it performs the transfer.

### What that removes from the goal

| | |
|---|---|
| `maven-artifact-transfer` | `ArtifactResolver`, `DependencyResolver`, `DependableCoordinate`, `ArtifactCoordinate` |
| deprecated Maven 3 repository model | `ArtifactRepository`, `MavenArtifactRepository`, `ArtifactRepositoryPolicy`, `ArtifactRepositoryLayout`, `ProjectBuildingRequest` |

`GetMojo` now compiles without a single deprecation warning. `maven-artifact-transfer` stays in the pom — `purge-local-repository`, `copy-dependencies` and `ArtifactItem` still use it (MDEP-858).

### Behaviour changes worth a release note

1. **`remoteRepositories` is `List<String>` instead of a comma-separated `String`**, same as `list-classes` since MDEP-924. The comma-separated form is **not** broken — verified against real Maven on both binding paths, each pinned by an IT: `-DremoteRepositories=a,b` (`get-remote-repositories`) and `<remoteRepositories>a,b</remoteRepositories>` as element text (`get-remote-repositories-pom-config`), the form used while the parameter was a `String`. POM configuration additionally gains the one-per-element form. Both ITs fail with `Invalid repository: …` if the value is collapsed into a single element, so they are not vacuous.
2. **The repository syntax is more permissive.** `id::url` (two tokens) now works, and an unknown layout id is no longer a build failure. Previously only `id::layout::url` and a bare URL were accepted.
3. **Extra repositories are no longer forced to `updatePolicy=always`.** They follow the session, with `-U` still forcing it — like every other goal that resolves through `ResolverUtil`.
4. **A packaging that carries a classifier now implies it.** `-Dpackaging=test-jar` used to download the main jar, because the old code took only `ArtifactHandler.getExtension()` and left the classifier empty; the resolver `ArtifactType` supplies both, so it now fetches the `-tests` jar. Same for `ejb-client`. This looks like the intended meaning of the parameter, but it does change what an existing command line downloads.
5. **Non-transitive `get` now reads the artifact descriptor first**, so it follows relocation (consistent with 37126112 "Fix artifact relocation support") and downloads the POM alongside the artifact. A missing or invalid POM stays tolerated — the session's `SimpleArtifactDescriptorPolicy(true, true)` still applies.

A third, `id::url` no longer being rejected, has an edge: a URL that itself contains `::` — an IPv6 literal such as `http://[::1]:8080/repo` — is now split into a nonsense id and url instead of failing with "Invalid syntax for repository". That is pre-existing `ResolverUtil` behaviour shared with `list-classes`; happy to add a guard here if you'd rather it stay loud.

### On the earlier approach in this PR

The first version added a `RepositorySessionInjector` that reimplemented `MavenRepositorySystem`'s session-based `injectMirror`/`injectProxy`/`injectAuthentication`. That was unnecessary — `newResolutionRepositories` does the same selection through API a plugin is allowed to use — so the class is gone, and with it both review comments (@elharo: it should not be a public standalone class; Copilot: it could return an empty `Authentication`).

Worth recording, since it cost a full IT run to find: **maven-core does not export `org.apache.maven.bridge` to plugin class realms.** In plexus-classworlds a plain package name matches recursively while the `.*` form matches only classes directly in that package, so maven-core exports `org.apache.maven.artifact.**`, `org.apache.maven.repository.**`, `org.apache.maven.settings.**`, `org.apache.maven.RepositoryUtils` and `org.eclipse.aether.**`, and nothing under `org.apache.maven.bridge`. Same in 3.9.16 and 4.0.0-rc-5. A plugin referencing `MavenRepositorySystem` compiles, passes every unit test, and then fails at runtime with `NoClassDefFoundError`. The plugin-testing harness uses one flat classpath with no realm isolation, so for changes touching maven-core internals `mvn verify` is not a sufficient bar — `-Prun-its` is.

### Tests

The proxy and credential tests come from #1678, where they were shown to fail when the injection is removed from the *current* implementation. Here they keep passing with the same assertions; they only change where the selection is read from — the repository session's selectors rather than the `Settings` list. Same tests, both implementations, same outcomes, so they characterise behaviour rather than agreeing with the new code.

`testParseRepository` is dropped along with `parseRepository`; `ResolverUtilTest.prepareRepositoryTest` already covers the same syntax. `testMissingArtifact` and `testInvalidArtifact` replace the argument validation that stayed in the mojo.

The second commit closes two gaps that `parseRepository` and the mojo's own token check used to cover, and that the migration would otherwise have exposed:

* **repository specs were not trimmed.** `parseRepository` trimmed its regex groups, so `-DremoteRepositories="repo1::https://a, repo2::https://b"` worked. The converter that turns the property into a `List<String>` splits on `,` without trimming, so the second element arrives as `" repo2::https://b"` and the repository is registered under the id `" repo2"` — a `<server>` for `repo2` then stops matching and **credentials are silently not applied**. That is the one I would have shipped as a real regression.
* **an `artifact` with more than five tokens was rejected**; `ResolverUtil` only checked for fewer than three, so `-Dartifact=g:a:v:jar:c:junk` went from a clear failure to silently ignoring the tail.

Both are in shared code, so `list-classes` gets the same fix. Each new case fails without it (verified by reverting the fix and re-running).

### Numbers

422 unit tests pass; the full `-Prun-its` suite is 101 passed / 0 failed (99 baseline + the two new ITs). `dependency:analyze-only` clean.

<sub>Drafted with Claude — please verify</sub>
