### PR TITLE
Drop the maven-compat test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -370,14 +370,6 @@ under the License.
       <scope>test</scope>
     </dependency>
 
-    <!-- Remove once deprecated code has been replaced/removed  -->
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${mavenVersion}</version>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>

--- a/src/test/java/org/apache/maven/artifact/repository/metadata/SnapshotArtifactRepositoryMetadata.java
+++ b/src/test/java/org/apache/maven/artifact/repository/metadata/SnapshotArtifactRepositoryMetadata.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.artifact.repository.metadata;
+
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+
+/**
+ * Metadata for the artifact version directory of the repository.
+ * <p>
+ * Class copied verbatim from maven-compat so that the maven-compat dependency can be dropped. It is used by the
+ * unit tests only, never by the plugin itself, and it is a plain data holder over
+ * {@link AbstractRepositoryMetadata} (which lives in maven-core), so copying it is enough — there is no component
+ * implementation left behind in maven-compat. Same technique as maven-plugin-plugin used for
+ * {@code GroupRepositoryMetadata} in MPLUGIN-384.
+ *
+ * @author <a href="mailto:brett@apache.org">Brett Porter</a>
+ */
+public class SnapshotArtifactRepositoryMetadata extends AbstractRepositoryMetadata {
+    private final Artifact artifact;
+
+    public SnapshotArtifactRepositoryMetadata(Artifact artifact) {
+        super(createMetadata(artifact, null));
+        this.artifact = artifact;
+    }
+
+    public SnapshotArtifactRepositoryMetadata(Artifact artifact, Snapshot snapshot) {
+        super(createMetadata(artifact, createVersioning(snapshot)));
+        this.artifact = artifact;
+    }
+
+    @Override
+    public boolean storedInGroupDirectory() {
+        return false;
+    }
+
+    @Override
+    public boolean storedInArtifactVersionDirectory() {
+        return true;
+    }
+
+    @Override
+    public String getGroupId() {
+        return artifact.getGroupId();
+    }
+
+    @Override
+    public String getArtifactId() {
+        return artifact.getArtifactId();
+    }
+
+    @Override
+    public String getBaseVersion() {
+        return artifact.getBaseVersion();
+    }
+
+    @Override
+    public Object getKey() {
+        return "snapshot " + artifact.getGroupId() + ":" + artifact.getArtifactId() + ":" + artifact.getBaseVersion();
+    }
+
+    @Override
+    public boolean isSnapshot() {
+        return artifact.isSnapshot();
+    }
+
+    @Override
+    public int getNature() {
+        return isSnapshot() ? SNAPSHOT : RELEASE;
+    }
+
+    @Override
+    public ArtifactRepository getRepository() {
+        return artifact.getRepository();
+    }
+
+    @Override
+    public void setRepository(ArtifactRepository remoteRepository) {
+        artifact.setRepository(remoteRepository);
+    }
+}


### PR DESCRIPTION
Last piece of the three-part split of the original #1677. Now that #1677 has merged, this is rebased onto `master` and is a **single commit**.

Nothing needs `LegacyRepositorySystem` any more: `dependency:get` stopped using the legacy `org.apache.maven.repository.RepositorySystem` in #1677, and that interface's only implementation is the one `maven-compat` supplies.

I checked the dependency direction rather than assuming it. With `maven-compat` removed from the pom and the vendored class in place, but `GetMojo` unchanged, `TestCopyDependenciesMojo2` passed 13/13 while all four `TestGetMojo` tests failed to provision the mojo — which is why this had to wait for #1677 rather than going first.

### The one judgement call

`SnapshotArtifactRepositoryMetadata` is copied into the test tree rather than deleting its two usages. `TestCopyDependenciesMojo2.assertArtifactExists` iterates `artifact.getMetadataList()` and asserts a file exists — dropping the attachment leaves that loop empty and silently removes the check, which is worse than vendoring.

The split is upstream's own: `AbstractRepositoryMetadata`, `RepositoryMetadata` and `ArtifactRepositoryMetadata` are all in maven-core 3.9.x, and only this leaf lives in `maven-compat` — the same situation as MPLUGIN-384. The copy matches maven-compat 3.9.16 method for method.

The non-vendoring alternative, maven-core's `ArtifactRepositoryMetadata`, is *artifact*-level metadata (`storedInArtifactVersionDirectory()` is false), so it would move the asserted `maven-metadata` path out of the snapshot version directory and weaken the assertion. Happy to go that way instead if the preference is to keep copied classes out of the test tree.

422 unit tests pass.

<sub>Drafted with Claude — please verify</sub>