### PR TITLE
Use a MojoExecutionException constructor that exists in Maven 3.6.3

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/RenderDependenciesMojo.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/fromDependencies/RenderDependenciesMojo.java
@@ -238,7 +238,7 @@ public class RenderDependenciesMojo extends AbstractDependencyFilterMojo {
             try {
                 Files.createDirectories(parent);
             } catch (final IOException e) {
-                throw new MojoExecutionException(e);
+                throw new MojoExecutionException("Error while creating directory '" + parent + "'", e);
             }
         }
 


### PR DESCRIPTION
`MojoExecutionException(Throwable)` arrived in Maven 3.9.0, so on the version `<prerequisites>`
declares, `RenderDependenciesMojo.store` raised `NoSuchMethodError` instead of the exception it
meant to throw. The reference is in released bytecode for 3.9.0, 3.10.0 and 3.11.0, not just in
source.

The message follows the sibling `catch` a few lines below rather than the bare `e.getMessage()`
the issue sketched, so the failure names the directory it could not create.

### No unit test accompanies this

Not an omission. Compiled against the current `<mavenVersion>` (3.9.16) the constructor exists,
so any test of this branch passes with or without the fix. The only check that fails without it
is compiling against the baseline itself:

```
Verified: mvn -DmavenVersion=3.6.3 clean test-compile → BUILD SUCCESS; fails to compile on the parent commit
```

That check is #1683, which is red today for precisely this reason and goes green once this lands.
Merge this first — landing the guard first would turn master red.

Fixes #1682

<sub>Drafted with Claude — please verify</sub>