### PR TITLE
Implement getOutputPath() and deprecate getOutputName()

### DIFF
--- a/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeReport.java
+++ b/src/main/java/org/apache/maven/plugins/dependency/analyze/AnalyzeReport.java
@@ -141,10 +141,19 @@ public class AnalyzeReport extends AbstractMavenReport {
     }
 
     /**
+     * @deprecated use {@link #getOutputPath()} instead
+     */
+    @Override
+    @Deprecated
+    public String getOutputName() {
+        return getOutputPath();
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override
-    public String getOutputName() {
+    public String getOutputPath() {
         return "dependency-analysis";
     }
 


### PR DESCRIPTION
Adopts the report output method that Maven Reporting API 4.0.0 introduced, following the pattern in the [report plugin guide](https://maven.apache.org/guides/plugin/guide-java-report-plugin-development.html) and already used by maven-javadoc-plugin and maven-pmd-plugin: `getOutputPath()` carries the value, and `getOutputName()` stays as a deprecated delegate because the API still declares it abstract.

No behaviour change — the rendered report paths are the same strings.

*This change was created with AI assistance.*
